### PR TITLE
Configure slurmd as a consul service

### DIFF
--- a/data/common.yaml
+++ b/data/common.yaml
@@ -1,0 +1,3 @@
+---
+consul_template::version: 0.24.1
+consul::version: 1.7.1

--- a/data/terraform_data.yaml.tmpl
+++ b/data/terraform_data.yaml.tmpl
@@ -17,6 +17,5 @@ profile::freeipa::client::server_ip: "${mgmt1_ip}"
 profile::consul::client::server_ip: "${mgmt1_ip}"
 profile::nfs::client::server_ip: "${mgmt1_ip}"
 profile::rsyslog::client::server_ip: "${mgmt1_ip}"
-profile::cvmfs::client::squid_ip: "${mgmt1_ip}"
 
 profile::reverse_proxy::domain_name: "${domain_name}"

--- a/data/terraform_data.yaml.tmpl
+++ b/data/terraform_data.yaml.tmpl
@@ -16,6 +16,5 @@ profile::slurm::accounting::password: "${freeipa_passwd}"
 profile::freeipa::client::server_ip: "${mgmt1_ip}"
 profile::consul::client::server_ip: "${mgmt1_ip}"
 profile::nfs::client::server_ip: "${mgmt1_ip}"
-profile::rsyslog::client::server_ip: "${mgmt1_ip}"
 
 profile::reverse_proxy::domain_name: "${domain_name}"

--- a/manifests/site.pp
+++ b/manifests/site.pp
@@ -44,6 +44,7 @@ node /^mgmt1$/ {
 
 node /^mgmt(?:[2-9]|[1-9]\d\d*)$/ {
   include profile::consul::client
+  include profile::slurm::controller
   include profile::base
   include profile::rsyslog::client
   include profile::freeipa::client

--- a/manifests/site.pp
+++ b/manifests/site.pp
@@ -26,19 +26,10 @@ node /^login\d+$/ {
 }
 
 node /^mgmt1$/ {
-  class { [
-    'profile::consul::server',
-    'profile::metrics::exporter'
-    ]:
-    stage => 'first'
-  }
-
-  class { [
-    'profile::freeipa::server',
-    'profile::nfs::server',
-    ]:
-    stage => 'second'
-  }
+  include profile::consul::server
+  include profile::metrics::exporter
+  include profile::freeipa::server
+  include profile::nfs::server
 
   include profile::metrics::server
   include profile::rsyslog::server

--- a/site/profile/files/cvmfs/z-00-computecanada.sh.ctmpl
+++ b/site/profile/files/cvmfs/z-00-computecanada.sh.ctmpl
@@ -1,6 +1,4 @@
-archs=({{ with tree "cvmfs/client" | explode -}}
-{{range $key, $value := . -}}
-{{ $value.rsnt_arch }} {{ end -}} {{ end -}})
+archs=({{ range service "cvmfs" }}{{.ServiceMeta.arch}} {{ end }})
 if [[ " ${archs[@]} " =~ " sse3 " ]]; then
     export RSNT_ARCH="sse3"
 elif [[ " ${archs[@]} " =~ " avx " ]]; then

--- a/site/profile/manifests/base.pp
+++ b/site/profile/manifests/base.pp
@@ -11,7 +11,7 @@ class profile::base (String $sudoer_username = 'centos') {
       'consul' => {
         'token' => lookup('profile::consul::acl_api_token')
       }
-    }
+    },
   }
 
   # Allow users to run TCP servers - activated to allow users

--- a/site/profile/manifests/consul.pp
+++ b/site/profile/manifests/consul.pp
@@ -1,6 +1,5 @@
 class profile::consul::server {
   class { '::consul':
-    version       => '1.6.1',
     config_mode   => '0640',
     acl_api_token => lookup('profile::consul::acl_api_token'),
     config_hash   => {
@@ -31,7 +30,6 @@ class profile::consul::server {
 
 class profile::consul::client(String $server_ip) {
   class { '::consul':
-    version     => '1.6.1',
     config_mode => '0640',
     config_hash => {
       'data_dir'        => '/opt/consul',

--- a/site/profile/manifests/cvmfs.pp
+++ b/site/profile/manifests/cvmfs.pp
@@ -24,17 +24,17 @@ class profile::cvmfs::client (String $squid_ip) {
     require => Package['cvmfs']
   }
 
-  consul_key_value { "cvmfs/client/${facts['hostname']}/rsnt_arch":
-    ensure        => 'present',
-    value         => $facts['cpu_ext'],
-    require       => Tcp_conn_validator['consul'],
-    acl_api_token => lookup('profile::consul::acl_api_token')
+  consul::service{ 'cvmfs':
+    require => Tcp_conn_validator['consul'],
+    token   => lookup('profile::consul::acl_api_token'),
+    meta    => {
+      arch => $facts['cpu_ext'],
+    },
   }
 
   file { '/etc/consul-template/z-00-computecanada.sh.ctmpl':
-    ensure  => 'present',
-    source  => 'puppet:///modules/profile/cvmfs/z-00-computecanada.sh.ctmpl',
-    require => File['/etc/cvmfs/default.local']
+    ensure => 'present',
+    source => 'puppet:///modules/profile/cvmfs/z-00-computecanada.sh.ctmpl',
   }
 
   consul_template::watch { 'z-00-computecanada.sh':

--- a/site/profile/manifests/cvmfs.pp
+++ b/site/profile/manifests/cvmfs.pp
@@ -1,4 +1,4 @@
-class profile::cvmfs::client (String $squid_ip) {
+class profile::cvmfs::client {
   package { 'cvmfs-repo':
     ensure   => 'installed',
     provider => 'rpm',
@@ -18,9 +18,9 @@ class profile::cvmfs::client (String $squid_ip) {
     require => [Package['cvmfs-repo'], Package['cc-cvmfs-repo']]
   }
 
-  file { '/etc/cvmfs/default.local':
+  file { '/etc/cvmfs/default.local.ctmpl':
     ensure  => 'present',
-    content => epp('profile/cvmfs/default.local', { 'squid_ip' => $squid_ip }),
+    content => epp('profile/cvmfs/default.local'),
     require => Package['cvmfs']
   }
 
@@ -47,10 +47,19 @@ class profile::cvmfs::client (String $squid_ip) {
     }
   }
 
+  consul_template::watch { '/etc/cvmfs/default.local':
+    require     => File['/etc/cvmfs/default.local.ctmpl'],
+    config_hash => {
+      perms       => '0644',
+      source      => '/etc/cvmfs/default.local.ctmpl',
+      destination => '/etc/cvmfs/default.local',
+      command     => 'systemctl reload autofs',
+    }
+  }
+
   service { 'autofs':
-    ensure  => running,
-    enable  => true,
-    require => File['/etc/cvmfs/default.local']
+    ensure => running,
+    enable => true,
   }
 
   # Fix issue with BASH_ENV, SSH and lmod where

--- a/site/profile/manifests/slurm.pp
+++ b/site/profile/manifests/slurm.pp
@@ -102,7 +102,8 @@ END
     owner   => 'slurm',
     group   => 'slurm',
     content => $node_template,
-    seltype => 'etc_t'
+    seltype => 'etc_t',
+    notify  => Service['consul-template'],
   }
 
   file { '/etc/slurm/plugstack.conf':
@@ -212,7 +213,8 @@ END
     group   => 'slurm',
     owner   => 'slurm',
     mode    => '0644',
-    require => File['/etc/slurm']
+    require => File['/etc/slurm'],
+    notify  => Service['consul-template'],
   }
 }
 

--- a/site/profile/manifests/squid.pp
+++ b/site/profile/manifests/squid.pp
@@ -1,16 +1,23 @@
-class profile::squid::server {
+class profile::squid::server (Integer $port = 3128) {
   package { 'squid':
     ensure => 'installed'
-  }
-
-  service { 'squid':
-    ensure => 'running',
-    enable => true
   }
 
   $cidr = profile::getcidr()
   file { '/etc/squid/squid.conf':
     ensure  => 'present',
-    content => epp('profile/squid/squid.conf', {'cidr' => $cidr})
+    content => epp('profile/squid/squid.conf', {'cidr' => $cidr, 'port' => $port})
+  }
+
+  service { 'squid':
+    ensure    => 'running',
+    enable    => true,
+    subscribe => File['/etc/squid/squid.conf'],
+  }
+
+  consul::service { 'squid':
+    port    => $port,
+    require => Tcp_conn_validator['consul'],
+    token   => lookup('profile::consul::acl_api_token'),
   }
 }

--- a/site/profile/templates/cvmfs/default.local.epp
+++ b/site/profile/templates/cvmfs/default.local.epp
@@ -1,4 +1,8 @@
 CVMFS_REPOSITORIES="cvmfs-config.computecanada.ca,soft.computecanada.ca"
 CVMFS_STRICT_MOUNT="yes"
 CVMFS_QUOTA_LIMIT=4450
-CVMFS_HTTP_PROXY="http://<%= $squid_ip %>:3128"
+{{ if service "squid" -}}
+CVMFS_HTTP_PROXY='{{ range service "squid" }}http://{{.Address}}:{{.Port}}|{{end}}'
+{{ else -}}
+CVMFS_HTTP_PROXY=DIRECT
+{{ end -}}

--- a/site/profile/templates/slurm/slurm.conf.epp
+++ b/site/profile/templates/slurm/slurm.conf.epp
@@ -3,8 +3,9 @@ ClusterName=<%= $cluster_name %>
 AuthType=auth/munge
 CryptoType=crypto/munge
 SlurmUser=slurm
-SlurmctldHost={{ key "slurmctld/hostname" }}({{ key "slurmctld/ip" }})
-
+{{ range service "slurmctld" -}}
+SlurmctldHost={{ .Node }}({{ .Address }})
+{{ end -}}
 # SCHEDULER CONFIGURATIONS
 SchedulerType=sched/backfill
 SelectType=select/cons_tres
@@ -12,9 +13,9 @@ SelectTypeParameters=CR_Core_Memory
 
 # NODE CONFIGURATIONS
 GresTypes=gpu
-{{ if tree "slurmd/" -}}
+{{ if service "slurmd" -}}
 include /etc/slurm/node.conf
-{{end -}}
+{{ end -}}
 
 # PARTITION CONFIGURATIONS
 PartitionName=cpubase_bycore_b1 Nodes=ALL Default=YES DefaultTime=1:00:00 DefMemPerCPU=256 OverSubscribe=YES
@@ -42,13 +43,15 @@ TaskPlugin=task/cgroup
 StateSaveLocation=/var/spool/slurm
 SallocDefaultCommand="srun -n1 -N1 --mem-per-cpu=0 --pty --preserve-env --mpi=none bash"
 
-{{ if keyExists "slurmdbd/hostname" }}
 ## Accounting
-AccountingStorageHost={{ key "slurmdbd/hostname" }}
+{{ range service "slurmdbd" -}}
+AccountingStorageHost={{ .Node }}
+{{ end -}}
+{{ if service "slurmdbd" -}}
 AccountingStorageType=accounting_storage/slurmdbd
 AccountingStorageTRES=gres/gpu,cpu,mem
 #AccountingStorageEnforce=limits
 JobAcctGatherType=jobacct_gather/cgroup
 JobAcctGatherFrequency=task=30
 JobAcctGatherParams=NoOverMemoryKill,UsePSS
-{{ end }}
+{{ end -}}

--- a/site/profile/templates/squid/squid.conf.epp
+++ b/site/profile/templates/squid/squid.conf.epp
@@ -20,7 +20,7 @@ http_access allow localhost
 http_access deny all
 
 # user-defined http_port
-http_port 3128
+http_port <%= $port %>
 
 # general settings
 coredump_dir                   /var/spool/squid


### PR DESCRIPTION
By configuring slurmd as a consul service, we no longer have to define custom key-values in Consul, we can simply define the service and add `cpus`, `realmemory` and `gpus` to the service metadata. We can then list the active `slurmd` with consul-template and build `node.conf` from this list. When a node is shutdown, the node and its service are unregistered from the catalog and consul-template update `node.conf`.