### PR TITLE
Create logical volumes with lvm based on disk ids

### DIFF
--- a/Puppetfile
+++ b/Puppetfile
@@ -8,7 +8,7 @@ mod 'KyleAnderson-consul',
 mod 'camptocamp-kmod', '2.3.1'
 mod 'camptocamp-systemd', '2.6.0'
 mod 'cmdntrf-consul_template', '2.3.0'
-mod 'derdanne-nfs', '2.1.2'
+mod 'derdanne-nfs', '2.1.4'
 mod 'heini-wait_for', '2.2.0'
 mod 'herculesteam-augeasproviders_core', '2.5.0'
 mod 'herculesteam-augeasproviders_pam', '2.2.1'

--- a/data/terraform_data.yaml.tmpl
+++ b/data/terraform_data.yaml.tmpl
@@ -17,8 +17,8 @@ profile::freeipa::client::server_ip: "${mgmt1_ip}"
 profile::consul::client::server_ip: "${mgmt1_ip}"
 profile::nfs::client::server_ip: "${mgmt1_ip}"
 
-profile::nfs::server::home_size: "${home_size}"
-profile::nfs::server::project_size: "${project_size}"
-profile::nfs::server::scratch_size: "${scratch_size}"
+profile::nfs::server::home_devices: ${home_dev}
+profile::nfs::server::project_devices: ${project_dev}
+profile::nfs::server::scratch_devices: ${scratch_dev}
 
 profile::reverse_proxy::domain_name: "${domain_name}"


### PR DESCRIPTION
Instead of puting all volumes in a single data pool, we take a list of glob expressions for each volume, and create a volume using all available space, removing the need for thin provisioning.