### PR TITLE
creates alien cache for ref mugqic

### DIFF
--- a/site/profile/templates/cvmfs/ref.mugqic.conf.epp
+++ b/site/profile/templates/cvmfs/ref.mugqic.conf.epp
@@ -1,0 +1,4 @@
+CVMFS_REPOSITORIES=ref.mugqic
+CVMFS_ALIEN_CACHE="/scratch/cvmfs_alien_cache/ref.mugqic"
+CVMFS_QUOTA_LIMIT='-1'
+CVMFS_SHARED_CACHE='no'


### PR DESCRIPTION
This PR comes with https://github.com/ComputeCanada/magic_castle/pull/118

I see two minor bumps in the way the implementation is done here. I think we ca live with them, but give some feedback please!

The cmvfs user uid and gid are set at the cloud init level to insure that is done before the cmvfs repo is installed. The alien cache path is created at the same time to ensure that it is own by the cvmfs user.

The repo that is in the alien cache (ref.mugqic) is hardcoded in the puppet module. 







