### PR TITLE
Adds a puppet module for Duo MFA and the ability to configure it from the Terraform deployment

### DIFF
--- a/Puppetfile
+++ b/Puppetfile
@@ -41,3 +41,7 @@ mod 'computecanada-jupyterhub',
 mod 'KyleAnderson-consul',
     :git    => 'https://github.com/solarkennedy/puppet-consul.git',
     :commit => '4dc9835cbdff6036bf371f648d3723298a88e648'
+
+mod 'iu-duounix',
+    :git => 'https://github.com/indiana-university/puppet-duo_unix.git',
+    :ref => 'v2.0.0'

--- a/Puppetfile
+++ b/Puppetfile
@@ -12,6 +12,7 @@ mod 'herculesteam-augeasproviders_pam', '2.2.1'
 mod 'herculesteam-augeasproviders_shellvar', '4.0.0'
 mod 'herculesteam-augeasproviders_ssh', '3.3.0'
 mod 'herculesteam-augeasproviders_sysctl', '2.5.0'
+mod 'iu-duo_unix', '2.0.0'
 mod 'petems-swap_file', '4.0.2'
 mod 'puppet-archive', '4.5.0'
 mod 'puppet-epel', '3.0.1'
@@ -41,7 +42,3 @@ mod 'computecanada-jupyterhub',
 mod 'KyleAnderson-consul',
     :git    => 'https://github.com/solarkennedy/puppet-consul.git',
     :commit => '4dc9835cbdff6036bf371f648d3723298a88e648'
-
-mod 'iu-duo_unix',
-    :git => 'https://github.com/indiana-university/puppet-duo_unix.git',
-    :ref => 'v2.0.0'

--- a/Puppetfile
+++ b/Puppetfile
@@ -42,6 +42,6 @@ mod 'KyleAnderson-consul',
     :git    => 'https://github.com/solarkennedy/puppet-consul.git',
     :commit => '4dc9835cbdff6036bf371f648d3723298a88e648'
 
-mod 'iu-duounix',
+mod 'iu-duo_unix',
     :git => 'https://github.com/indiana-university/puppet-duo_unix.git',
     :ref => 'v2.0.0'

--- a/README.md
+++ b/README.md
@@ -95,11 +95,11 @@ variables for each profile.
 
 ## profile::mfa
 
-| Variable                              | Type           | Description                                                                 | Default  |
-| ------------------------------------- | :------------- | :-------------------------------------------------------------------------- | -------- |
-| `profile::mfa::duo:mgmt`              | Boolean        | Enable MFA on mgmt nodes                                                    | false    |
-| `profile::mfa::duo:login`             | Boolean        | Enable MFA on login nodes                                                   | false    |
-| `profile::mfa::duo:node`              | Boolean        | Enable MFA on compute nodes                                                 | false    |
+| Variable                              | Type                | Description                                                                 | Default  |
+| ------------------------------------- | :------------------ | :-------------------------------------------------------------------------- | -------- |
+| `profile::mfa::mgmt`                  | Enum['none', 'duo'] | Choose MFA provider on mgmt nodes                                           | false    |
+| `profile::mfa::login`                 | Enum['none', 'duo'] | Choose MFA provider on login nodes                                          | false    |
+| `profile::mfa::node`                  | Enum['none', 'duo'] | Choose MFA provider on compute nodes                                        | false    |
 
 ## duo_unix
 

--- a/README.md
+++ b/README.md
@@ -92,3 +92,21 @@ variables for each profile.
 | --------------------------------- | :----- | :------------------------------------------------------------------------------ | ------------------------ |
 | `profile::workshop::userzip_url`  | String | URL pointing to a zip that needs to be extracted in each guest account's home   | `''`                     |
 | `profile::workshop::userzip_path` | String | Path on the nfs server where to save the userzip archive                        | `'/project/userzip.zip'` |
+
+## profile::mfa
+
+| Variable                              | Type           | Description                                                                 | Default  |
+| ------------------------------------- | :------------- | :-------------------------------------------------------------------------- | -------- |
+| `profile::mfa::duo:mgmt`              | Boolean        | Enable MFA on mgmt nodes                                                    | false    |
+| `profile::mfa::duo:login`             | Boolean        | Enable MFA on login nodes                                                   | false    |
+| `profile::mfa::duo:node`              | Boolean        | Enable MFA on compute nodes                                                 | false    |
+
+## duo_unix
+
+| Variable                          | Type   | Description                                                                     | Default                  |
+| --------------------------------- | :----- | :------------------------------------------------------------------------------ | ------------------------ |
+| `duo_unix::usage`                 | String | Either login or pam                                                             | `login`                  |
+| `duo_unix::ikey`                  | String | Duo integration key                                                             | `''`                     |
+| `duo_unix::skey`                  | String | Duo secret key                                                                  | `''`                     |
+| `duo_unix::host`                  | String | Duo api host                                                                    | `''`                     |
+| `duo_unux::motd`                  | String | Enable motd                                                                     | `no`                     |

--- a/data/common.yaml
+++ b/data/common.yaml
@@ -53,5 +53,6 @@ profile::cvmfs::client::repositories:
   - soft.computecanada.ca
 profile::cvmfs::client::quota_limit: 4096
 
-duo_unix::usage: login
-duo_unux::motd: no
+profile::mfa::duo::mgmt: false
+profile::mfa::duo::node: false
+profile::mfa::duo::login: false

--- a/data/common.yaml
+++ b/data/common.yaml
@@ -52,3 +52,6 @@ profile::cvmfs::client::repositories:
   - cvmfs-config.computecanada.ca
   - soft.computecanada.ca
 profile::cvmfs::client::quota_limit: 4096
+
+duo_unix::usage: login
+duo_unux::motd: no

--- a/data/common.yaml
+++ b/data/common.yaml
@@ -53,6 +53,6 @@ profile::cvmfs::client::repositories:
   - soft.computecanada.ca
 profile::cvmfs::client::quota_limit: 4096
 
-profile::mfa::duo::mgmt: false
-profile::mfa::duo::node: false
-profile::mfa::duo::login: false
+profile::mfa::mgmt: 'none'
+profile::mfa::node: 'none'
+profile::mfa::login: 'none'

--- a/data/common.yaml
+++ b/data/common.yaml
@@ -53,6 +53,6 @@ profile::cvmfs::client::repositories:
   - soft.computecanada.ca
 profile::cvmfs::client::quota_limit: 4096
 
-profile::mfa::mgmt: 'none'
-profile::mfa::node: 'none'
-profile::mfa::login: 'none'
+profile::mfa::mgmt::provider: 'none'
+profile::mfa::node::provider: 'none'
+profile::mfa::login::provider: 'none'

--- a/manifests/site.pp
+++ b/manifests/site.pp
@@ -40,7 +40,7 @@ node /^mgmt1$/ {
   include profile::freeipa::guest_accounts
   include profile::slurm::accounting
   include profile::workshop::mgmt
-}
+  include iu-duounix
 
 node /^mgmt(?:[2-9]|[1-9]\d\d*)$/ {
   include profile::consul::client

--- a/manifests/site.pp
+++ b/manifests/site.pp
@@ -23,6 +23,9 @@ node /^login\d+$/ {
   include profile::reverse_proxy
   include profile::nfs::client
   include profile::freeipa::client
+  if $duo_unix::login {
+    include duo_unix
+  }
 }
 
 node /^mgmt1$/ {
@@ -40,7 +43,9 @@ node /^mgmt1$/ {
   include profile::freeipa::guest_accounts
   include profile::slurm::accounting
   include profile::workshop::mgmt
-  include duo_unix
+  if $duo_unix::mgmt {
+    include duo_unix
+  }
 }
 
 node /^mgmt(?:[2-9]|[1-9]\d\d*)$/ {
@@ -50,7 +55,9 @@ node /^mgmt(?:[2-9]|[1-9]\d\d*)$/ {
   include profile::rsyslog::client
   include profile::freeipa::client
   include profile::metrics::exporter
-  include duo_unix
+  if $duo_unix::mgmt {
+    include duo_unix
+  }
 }
 
 node /^[a-z0-9-]*node\d+$/ {
@@ -66,5 +73,8 @@ node /^[a-z0-9-]*node\d+$/ {
   include profile::nfs::client
   include profile::slurm::node
   include profile::freeipa::client
-  include duo_unix
+  if $duo_unix::node {
+    include duo_unix
+  }
+
 }

--- a/manifests/site.pp
+++ b/manifests/site.pp
@@ -22,10 +22,7 @@ node /^login\d+$/ {
   include profile::jupyterhub::hub
   include profile::reverse_proxy
   include profile::nfs::client
-  include profile::freeipa::client
-  if $duo_unix::login {
-    include duo_unix
-  }
+  include profile::mfa::duo::login
 }
 
 node /^mgmt1$/ {
@@ -43,9 +40,7 @@ node /^mgmt1$/ {
   include profile::freeipa::guest_accounts
   include profile::slurm::accounting
   include profile::workshop::mgmt
-  if $duo_unix::mgmt {
-    include duo_unix
-  }
+  include profile::mfa::duo::mgmt
 }
 
 node /^mgmt(?:[2-9]|[1-9]\d\d*)$/ {
@@ -55,9 +50,7 @@ node /^mgmt(?:[2-9]|[1-9]\d\d*)$/ {
   include profile::rsyslog::client
   include profile::freeipa::client
   include profile::metrics::exporter
-  if $duo_unix::mgmt {
-    include duo_unix
-  }
+  include profile::mfa::duo::mgmt
 }
 
 node /^[a-z0-9-]*node\d+$/ {
@@ -73,8 +66,6 @@ node /^[a-z0-9-]*node\d+$/ {
   include profile::nfs::client
   include profile::slurm::node
   include profile::freeipa::client
-  if $duo_unix::node {
-    include duo_unix
-  }
+  include profile::mfa::duo::node
 
 }

--- a/manifests/site.pp
+++ b/manifests/site.pp
@@ -22,6 +22,7 @@ node /^login\d+$/ {
   include profile::jupyterhub::hub
   include profile::reverse_proxy
   include profile::nfs::client
+  include profile::freeipa::client
   include profile::mfa::duo::login
 }
 

--- a/manifests/site.pp
+++ b/manifests/site.pp
@@ -66,5 +66,5 @@ node /^[a-z0-9-]*node\d+$/ {
   include profile::nfs::client
   include profile::slurm::node
   include profile::freeipa::client
-  include iu-duo_unix
+  include duo_unix
 }

--- a/manifests/site.pp
+++ b/manifests/site.pp
@@ -23,7 +23,7 @@ node /^login\d+$/ {
   include profile::reverse_proxy
   include profile::nfs::client
   include profile::freeipa::client
-  include profile::mfa::duo::login
+  include profile::mfa::login
 }
 
 node /^mgmt1$/ {
@@ -41,7 +41,7 @@ node /^mgmt1$/ {
   include profile::freeipa::guest_accounts
   include profile::slurm::accounting
   include profile::workshop::mgmt
-  include profile::mfa::duo::mgmt
+  include profile::mfa::mgmt
 }
 
 node /^mgmt(?:[2-9]|[1-9]\d\d*)$/ {
@@ -51,7 +51,7 @@ node /^mgmt(?:[2-9]|[1-9]\d\d*)$/ {
   include profile::rsyslog::client
   include profile::freeipa::client
   include profile::metrics::exporter
-  include profile::mfa::duo::mgmt
+  include profile::mfa::mgmt
 }
 
 node /^[a-z0-9-]*node\d+$/ {
@@ -67,6 +67,6 @@ node /^[a-z0-9-]*node\d+$/ {
   include profile::nfs::client
   include profile::slurm::node
   include profile::freeipa::client
-  include profile::mfa::duo::node
+  include profile::mfa::node
 
 }

--- a/manifests/site.pp
+++ b/manifests/site.pp
@@ -40,7 +40,7 @@ node /^mgmt1$/ {
   include profile::freeipa::guest_accounts
   include profile::slurm::accounting
   include profile::workshop::mgmt
-  include iu-duo_unix
+  include duo_unix
 }
 
 node /^mgmt(?:[2-9]|[1-9]\d\d*)$/ {
@@ -50,7 +50,7 @@ node /^mgmt(?:[2-9]|[1-9]\d\d*)$/ {
   include profile::rsyslog::client
   include profile::freeipa::client
   include profile::metrics::exporter
-  include iu-duo_unix
+  include duo_unix
 }
 
 node /^[a-z0-9-]*node\d+$/ {

--- a/manifests/site.pp
+++ b/manifests/site.pp
@@ -41,6 +41,7 @@ node /^mgmt1$/ {
   include profile::slurm::accounting
   include profile::workshop::mgmt
   include iu-duo_unix
+}
 
 node /^mgmt(?:[2-9]|[1-9]\d\d*)$/ {
   include profile::consul::client

--- a/manifests/site.pp
+++ b/manifests/site.pp
@@ -40,7 +40,7 @@ node /^mgmt1$/ {
   include profile::freeipa::guest_accounts
   include profile::slurm::accounting
   include profile::workshop::mgmt
-  include iu-duounix
+  include iu-duo_unix
 
 node /^mgmt(?:[2-9]|[1-9]\d\d*)$/ {
   include profile::consul::client
@@ -49,6 +49,7 @@ node /^mgmt(?:[2-9]|[1-9]\d\d*)$/ {
   include profile::rsyslog::client
   include profile::freeipa::client
   include profile::metrics::exporter
+  include iu-duo_unix
 }
 
 node /^[a-z0-9-]*node\d+$/ {
@@ -64,4 +65,5 @@ node /^[a-z0-9-]*node\d+$/ {
   include profile::nfs::client
   include profile::slurm::node
   include profile::freeipa::client
+  include iu-duo_unix
 }

--- a/site/profile/manifests/mfa.pp
+++ b/site/profile/manifests/mfa.pp
@@ -1,19 +1,19 @@
 # MFA class which allows for multiple MFA implementations to
 # be deployed in one cluster deployment.
 class profile::mfa::duo::login {
-  if $profile::mfa::duo::login {
+  if lookup(profile::mfa::duo::login) {
     include duo_unix
   }
 }
 
 class profile::mfa::duo::mgmt {
-  if $profile::mfa::duo::mgmt {
+  if lookup(profile::mfa::duo::mgmt) {
     include duo_unix
   }
 }
 
 class profile::mfa::duo::node {
-  if $profile::mfa::duo::node {
+  if lookup(profile::mfa::duo::node) {
     include duo_unix
   }
 }

--- a/site/profile/manifests/mfa.pp
+++ b/site/profile/manifests/mfa.pp
@@ -1,19 +1,19 @@
 # MFA class which allows for multiple MFA implementations to
 # be deployed in one cluster deployment.
-class profile::mfa::duo::login {
-  if lookup(profile::mfa::duo::login) {
+class profile::mfa::login ( Enum['none', 'duo'] $provider ) {
+  if ($provider == 'duo') {
     include duo_unix
   }
 }
 
-class profile::mfa::duo::mgmt {
-  if lookup(profile::mfa::duo::mgmt) {
+class profile::mfa::mgmt ( Enum['none', 'duo'] $provider ) {
+  if ($provider == 'duo') {
     include duo_unix
   }
 }
 
-class profile::mfa::duo::node {
-  if lookup(profile::mfa::duo::node) {
+class profile::mfa::node ( Enum['none', 'duo'] $provider ) {
+  if ($provider == 'duo') {
     include duo_unix
   }
 }

--- a/site/profile/manifests/mfa.pp
+++ b/site/profile/manifests/mfa.pp
@@ -1,0 +1,19 @@
+# MFA class which allows for multiple MFA implementations to
+# be deployed in one cluster deployment.
+class profile::mfa::duo::login {
+  if $profile::mfa::duo::login {
+    include duo_unix
+  }
+}
+
+class profile::mfa::duo::mgmt {
+  if $profile::mfa::duo::mgmt {
+    include duo_unix
+  }
+}
+
+class profile::mfa::duo::node {
+  if $profile::mfa::duo::node {
+    include duo_unix
+  }
+}


### PR DESCRIPTION
This PR adds a Puppet module forked from the Duo Puppet module which was abandoned by Duo but picked up by Indiana University. The Duo configuration can be defined by creating a yaml files with the Duo api keys and included in user data when deploying a new cluster. By default no MFA deployment is done, the class is not added to node types but you can configure MFA on a type of node (login, mgmt, node) by adding the appropriate user data configuration.

profile::mfa::duo::login: true
profile::mfa::duo::mgmt: true
profile::mfa::duo::node: true