### PR TITLE
Consistently use `lib_symlink_path` for GPUs

### DIFF
--- a/site/profile/manifests/gpu.pp
+++ b/site/profile/manifests/gpu.pp
@@ -89,7 +89,7 @@ class profile::gpu::install (
     ]
 
     $nvidia_libs.each |String $lib| {
-      file { "/usr/lib64/nvidia/${lib}":
+      file { "${lib_symlink_path}/${lib}":
         ensure  => link,
         target  => "/usr/lib64/${lib}",
         seltype => 'lib_t'
@@ -130,7 +130,7 @@ class profile::gpu::install (
       ]
 
       $nvidia_libs_vers.each |String $lib| {
-        file { "/usr/lib64/nvidia/${lib}":
+        file { "${lib_symlink_path}/${lib}":
           ensure  => link,
           target  => "/usr/lib64/${lib}",
           seltype => 'lib_t'


### PR DESCRIPTION
Just noticed with the new EESSI release that MC was still trying to create the symlinks to `/usr/lib64/nvidia`