### PR TITLE
Fix cvmfs default.local initialization with consul-template

### DIFF
--- a/site/profile/manifests/cvmfs.pp
+++ b/site/profile/manifests/cvmfs.pp
@@ -44,6 +44,7 @@ class profile::cvmfs::client(
       'quota_limit'  => $quota_limit,
       'repositories' => $repositories,
     }),
+    notify  => Service['consul-template'],
     require => Package['cvmfs']
   }
 
@@ -58,6 +59,7 @@ class profile::cvmfs::client(
   file { '/etc/consul-template/z-00-rsnt_arch.sh.ctmpl':
     ensure => 'present',
     source => 'puppet:///modules/profile/cvmfs/z-00-rsnt_arch.sh.ctmpl',
+    notify => Service['consul-template'],
   }
 
   file { '/etc/profile.d/z-01-site.sh':


### PR DESCRIPTION
Consul template is executed to initialize CVMFS default.local file in order to make sure that when a class require the cvms client class, the software stack repos will be mounted.

Previously, consul-template was executed without the config flag, nor the consul ACL token, therefore it was unable to reach consul, and the default.local was initialized without the squid proxy. This was transparent to most users as the direct access to Compute Canada CVMFS is now almost as fast thanks to Cloudflare CDN. However, when trying to mount software repos that are restricted to certain ip, we need to use the squid proxy. Depending on when a restricted repo was added to the list, the cvmfs config was either wrong or right.

This patch fixes this.