### PR TITLE
Disable resource limit propagation in Slurm

### DIFF
--- a/site/profile/templates/slurm/slurm.conf.epp
+++ b/site/profile/templates/slurm/slurm.conf.epp
@@ -48,6 +48,7 @@ PlugStackConfig=/etc/slurm/plugstack.conf
 MpiDefault=pmi2
 ProctrackType=proctrack/cgroup
 TaskPlugin=task/cgroup
+PropagateResourceLimits=NONE
 
 StateSaveLocation=/var/spool/slurm
 <% if $slurm_version == '19.05' { -%>


### PR DESCRIPTION
Fix issue where AWS Elastic Fabric Adapter was not performing as expected when submitting from a login node without EFA driver installed.
More details here: https://github.com/ComputeCanada/magic_castle/pull/182