### PR TITLE
Generalize NFS volume exporting and mounting

### DIFF
--- a/data/common.yaml
+++ b/data/common.yaml
@@ -108,8 +108,6 @@ profile::freeipa::client::server_ip: "%{alias('terraform.tag_ip.mgmt.0')}"
 profile::consul::client::server_ip: "%{alias('terraform.tag_ip.puppet.0')}"
 profile::nfs::client::server_ip: "%{alias('terraform.tag_ip.nfs.0')}"
 
-profile::nfs::server::home_devices: "%{alias('terraform.volumes.nfs.home')}"
-profile::nfs::server::project_devices: "%{alias('terraform.volumes.nfs.project')}"
-profile::nfs::server::scratch_devices: "%{alias('terraform.volumes.nfs.scratch')}"
+profile::nfs::server::devices: "%{alias('terraform.volumes.nfs')}"
 
 profile::reverse_proxy::domain_name: "%{alias('terraform.data.domain_name')}"

--- a/site/profile/files/accounts/mkhome.sh
+++ b/site/profile/files/accounts/mkhome.sh
@@ -7,11 +7,12 @@ while read USERNAME; do
     restorecon -F -R $USER_HOME
 
     USER_SCRATCH="/scratch/$USERNAME"
-    if [[ ! -d "$USER_SCRATCH" ]]; then
-        mkdir -p $USER_SCRATCH
+    SERVER_SCRATCH="/mnt/$USER_SCRATCH"
+    if [[ ! -d "$MOUNT_SCRATCH" ]]; then
+        mkdir -p $SERVER_SCRATCH
         ln -sfT $USER_SCRATCH "$USER_HOME/scratch"
-        chown -h $USERNAME:$USERNAME $USER_SCRATCH "$USER_HOME/scratch"
-        chmod 750 $USER_SCRATCH
-        restorecon -F -R $USER_SCRATCH
+        chown -h $USERNAME:$USERNAME $SERVER_SCRATCH "$USER_HOME/scratch"
+        chmod 750 $SERVER_SCRATCH
+        restorecon -F -R $SERVER_SCRATCH
     fi
 done

--- a/site/profile/files/accounts/mkproject.sh
+++ b/site/profile/files/accounts/mkproject.sh
@@ -70,20 +70,22 @@ while read CONN OP GROUP; do
         # The operation that add users to a group would have operations with a uid.
         # If we found none, $USERNAMES will be empty, and it means we don't have
         # anything to add to Slurm and /project
-        if [[ ! -z "$USERNAMES" ]]; then
+        if [[ ! -z "${USERNAMES}" ]]; then
+            MNT_PROJECT="/mnt$(readlink /mnt/project/${GROUP})"
+<% if $with_folder { -%>
             for USERNAME in $USERNAMES; do
-                USER_HOME="/mnt/home/$USERNAME"
+                USER_HOME="/mnt/home/${USERNAME}"
 
-                PRO_USER="/mnt/project/$GROUP/$USERNAME"
-                mkdir -p $PRO_USER
-                mkdir -p "$USER_HOME/projects"
-                ln -sfT "/project/$GROUP" "$USER_HOME/projects/$GROUP"
+                PRO_USER="${MNT_PROJECT}/${USERNAME}"
+                mkdir -p ${PRO_USER}
+                mkdir -p "${USER_HOME}/projects"
+                ln -sfT "/project/${GROUP}" "${USER_HOME}/projects/${GROUP}"
 
-                chgrp $USERNAME "$USER_HOME/projects"
-                chown $USERNAME $PRO_USER
-                chmod 0755 "$USER_HOME/projects"
-                chmod 2700 $PRO_USER
-                restorecon -F -R /mnt/project/$GROUP/$USERNAME
+                chgrp "${USERNAME}" "${USER_HOME}/projects"
+                chown "${USERNAME}" "${PRO_USER}"
+                chmod 0755 "${USER_HOME}/projects"
+                chmod 2700 "${PRO_USER}"
+                restorecon -F -R "/mnt/project/${GROUP}/${USERNAME}"
             done
             /opt/software/slurm/bin/sacctmgr add user ${USERNAMES} Account=${GROUP} -i
         else

--- a/site/profile/files/accounts/mkproject.sh
+++ b/site/profile/files/accounts/mkproject.sh
@@ -56,10 +56,10 @@ while read CONN OP GROUP; do
         done
 
         # Then we create the project folder
-        mkdir -p "/project/$GID"
-        chown root:"$GROUP" "/project/$GID"
-        chmod 2770 "/project/$GID"
-        ln -sfT "/project/$GID" "/project/$GROUP"
+        mkdir -p "/mnt/project/$GID"
+        chown root:"$GROUP" "/mnt/project/$GID"
+        chmod 2770 "/mnt/project/$GID"
+        ln -sfT "/project/$GID" "/mnt/project/$GROUP"
         restorecon -F -R /project/$GID /project/$GROUP
 
     elif [[ "$OP" == "MOD" ]]; then
@@ -74,7 +74,7 @@ while read CONN OP GROUP; do
             for USERNAME in $USERNAMES; do
                 USER_HOME="/mnt/home/$USERNAME"
 
-                PRO_USER="/project/$GROUP/$USERNAME"
+                PRO_USER="/mnt/project/$GROUP/$USERNAME"
                 mkdir -p $PRO_USER
                 mkdir -p "$USER_HOME/projects"
                 ln -sfT "/project/$GROUP" "$USER_HOME/projects/$GROUP"
@@ -83,7 +83,7 @@ while read CONN OP GROUP; do
                 chown $USERNAME $PRO_USER
                 chmod 0755 "$USER_HOME/projects"
                 chmod 2700 $PRO_USER
-                restorecon -F -R /project/$GROUP/$USERNAME
+                restorecon -F -R /mnt/project/$GROUP/$USERNAME
             done
             /opt/software/slurm/bin/sacctmgr add user ${USERNAMES} Account=${GROUP} -i
         else

--- a/site/profile/manifests/accounts.pp
+++ b/site/profile/manifests/accounts.pp
@@ -44,13 +44,15 @@ class profile::accounts {
     owner  => 'root',
   }
 
-  service { 'mkproject':
-    ensure    => running,
-    enable    => true,
-    subscribe => [
-      File['/sbin/mkproject.sh'],
-      File['mkproject.service'],
-    ]
+  if defined(File['/mnt/project']) {
+    service { 'mkproject':
+      ensure    => running,
+      enable    => true,
+      subscribe => [
+        File['/sbin/mkproject.sh'],
+        File['mkproject.service'],
+      ]
+    }
   }
 }
 

--- a/site/profile/manifests/accounts.pp
+++ b/site/profile/manifests/accounts.pp
@@ -77,7 +77,7 @@ class profile::accounts::guests(
   if $nb_accounts > 0 {
     exec{ 'ipa_add_user':
       command     => "kinit_wrapper ipa_create_user.py $(seq -w ${nb_accounts} | sed 's/^/${prefix}/') --sponsor=${$sponsor}",
-      onlyif      => "test $(stat -c '%U' $(seq -w ${nb_accounts} | sed 's/^/\\/mnt\\/home\\/${prefix}/') | grep ${prefix} | wc -l) != ${nb_accounts}",
+      unless      => "getent passwd $(seq -w ${nb_accounts} | sed 's/^/${prefix}/')",
       environment => ["IPA_ADMIN_PASSWD=${admin_passwd}",
                       "IPA_GUEST_PASSWD=${passwd}"],
       path        => ['/bin', '/usr/bin', '/sbin','/usr/sbin'],

--- a/site/profile/manifests/accounts.pp
+++ b/site/profile/manifests/accounts.pp
@@ -9,10 +9,16 @@ class profile::accounts {
     mode   => '0755'
   }
 
+  $nfs_devices = lookup('profile::nfs::server::devices', undef, undef, {})
+  $with_home = 'home' in $nfs_devices
+  $with_project = 'project' in $nfs_devices
+  $with_scratch = 'scratch' in $nfs_devices
+
   file { '/sbin/mkhome.sh':
     ensure  => 'present',
     content => epp('profile/accounts/mkhome.sh', {
-      with_scratch => defined(File['/mnt/scratch']),
+      with_home    => $with_home,
+      with_scratch => $with_scratch,
     }),
     mode    => '0755',
     owner   => 'root',
@@ -42,7 +48,7 @@ class profile::accounts {
   file { '/sbin/mkproject.sh':
     ensure  => 'present',
     content => epp('profile/accounts/mkproject.sh', {
-      with_folder => defined(File['/mnt/project']),
+      with_folder => $with_project,
     }),
     mode    => '0755',
     owner   => 'root',

--- a/site/profile/manifests/accounts.pp
+++ b/site/profile/manifests/accounts.pp
@@ -30,13 +30,15 @@ class profile::accounts {
     source => 'puppet:///modules/profile/accounts/mkhome.service'
   }
 
-  service { 'mkhome':
-    ensure    => running,
-    enable    => true,
-    subscribe => [
-      File['/sbin/mkhome.sh'],
-      File['mkhome.service'],
-    ]
+  if $with_home or $with_scratch {
+    service { 'mkhome':
+      ensure    => running,
+      enable    => true,
+      subscribe => [
+        File['/sbin/mkhome.sh'],
+        File['mkhome.service'],
+      ]
+    }
   }
 
   file { 'mkproject.service':

--- a/site/profile/manifests/accounts.pp
+++ b/site/profile/manifests/accounts.pp
@@ -40,21 +40,21 @@ class profile::accounts {
   }
 
   file { '/sbin/mkproject.sh':
-    ensure => 'present',
-    source => 'puppet:///modules/profile/accounts/mkproject.sh',
-    mode   => '0755',
-    owner  => 'root',
+    ensure  => 'present',
+    content => epp('profile/accounts/mkproject.sh', {
+      with_folder => defined(File['/mnt/project']),
+    }),
+    mode    => '0755',
+    owner   => 'root',
   }
 
-  if defined(File['/mnt/project']) {
-    service { 'mkproject':
-      ensure    => running,
-      enable    => true,
-      subscribe => [
-        File['/sbin/mkproject.sh'],
-        File['mkproject.service'],
-      ]
-    }
+  service { 'mkproject':
+    ensure    => running,
+    enable    => true,
+    subscribe => [
+      File['/sbin/mkproject.sh'],
+      File['mkproject.service'],
+    ]
   }
 }
 

--- a/site/profile/manifests/accounts.pp
+++ b/site/profile/manifests/accounts.pp
@@ -10,10 +10,12 @@ class profile::accounts {
   }
 
   file { '/sbin/mkhome.sh':
-    ensure => 'present',
-    source => 'puppet:///modules/profile/accounts/mkhome.sh',
-    mode   => '0755',
-    owner  => 'root',
+    ensure  => 'present',
+    content => epp('profile/accounts/mkhome.sh', {
+      with_scratch => defined(File['/mnt/scratch']),
+    }),
+    mode    => '0755',
+    owner   => 'root',
   }
 
   file { 'mkhome.service':

--- a/site/profile/manifests/nfs.pp
+++ b/site/profile/manifests/nfs.pp
@@ -107,7 +107,7 @@ define profile::nfs::server::export_volume (
   String $seltype = 'home_root_t',
 ) {
 
-  $regexes =  regsubst($glob, /[?*]/, {'?' => '.', '*' => '.*' })
+  $regexes = regsubst($glob, /[?*]/, {'?' => '.', '*' => '.*' })
 
   file { ["/mnt/${name}"] :
     ensure  => directory,

--- a/site/profile/manifests/nfs.pp
+++ b/site/profile/manifests/nfs.pp
@@ -9,30 +9,12 @@ class profile::nfs::client (String $server_ip) {
     nfs_v4_idmap_domain => $nfs_domain
   }
 
-  $nfs_home    = ! empty(lookup('profile::nfs::server::devices.home', undef, undef, []))
-  $nfs_project = ! empty(lookup('profile::nfs::server::devices.project', undef, undef, []))
-  $nfs_scratch = ! empty(lookup('profile::nfs::server::devices.scratch', undef, undef, []))
-
-  # Retrieve all folder exported with NFS in a single mount
+  $nfs_export_list = keys(lookup('profile::nfs::server::devices', undef, undef, {}))
   $options_nfsv4 = 'proto=tcp,nosuid,nolock,noatime,actimeo=3,nfsvers=4.2,seclabel,bg'
-  if $nfs_home {
-    nfs::client::mount { '/home':
+  $nfs_export_list.each | String $name | {
+    nfs::client::mount { "/${name}":
         server        => $server_ip,
-        share         => 'home',
-        options_nfsv4 => $options_nfsv4
-    }
-  }
-  if $nfs_project {
-    nfs::client::mount { '/project':
-        server        => $server_ip,
-        share         => 'project',
-        options_nfsv4 => $options_nfsv4
-    }
-  }
-  if $nfs_scratch {
-    nfs::client::mount { '/scratch':
-        server        => $server_ip,
-        share         => 'scratch',
+        share         => $name,
         options_nfsv4 => $options_nfsv4
     }
   }

--- a/site/profile/manifests/nfs.pp
+++ b/site/profile/manifests/nfs.pp
@@ -9,9 +9,9 @@ class profile::nfs::client (String $server_ip) {
     nfs_v4_idmap_domain => $nfs_domain
   }
 
-  $nfs_home    = ! empty(lookup('profile::nfs::server::home_devices', undef, undef, []))
-  $nfs_project = ! empty(lookup('profile::nfs::server::project_devices', undef, undef, []))
-  $nfs_scratch = ! empty(lookup('profile::nfs::server::scratch_devices', undef, undef, []))
+  $nfs_home    = ! empty(lookup('profile::nfs::server::devices.home', undef, undef, []))
+  $nfs_project = ! empty(lookup('profile::nfs::server::devices.project', undef, undef, []))
+  $nfs_scratch = ! empty(lookup('profile::nfs::server::devices.scratch', undef, undef, []))
 
   # Retrieve all folder exported with NFS in a single mount
   $options_nfsv4 = 'proto=tcp,nosuid,nolock,noatime,actimeo=3,nfsvers=4.2,seclabel,bg'
@@ -38,7 +38,9 @@ class profile::nfs::client (String $server_ip) {
   }
 }
 
-class profile::nfs::server {
+class profile::nfs::server (
+  Hash[String, Array[String]] $devices,
+) {
   require profile::base
 
   $domain_name = lookup({ name          => 'profile::freeipa::base::domain_name',
@@ -105,9 +107,9 @@ END
     ensure => installed
   }
 
-  $home_dev_glob    = lookup('profile::nfs::server::home_devices', undef, undef, [])
-  $project_dev_glob = lookup('profile::nfs::server::project_devices', undef, undef, [])
-  $scratch_dev_glob = lookup('profile::nfs::server::scratch_devices', undef, undef, [])
+  $home_dev_glob    = lookup('profile::nfs::server::devices.home', undef, undef, [])
+  $project_dev_glob = lookup('profile::nfs::server::devices.project', undef, undef, [])
+  $scratch_dev_glob = lookup('profile::nfs::server::devices.scratch', undef, undef, [])
 
   $home_dev_regex = regsubst($home_dev_glob, /[?*]/, {'?' => '.', '*' => '.*' })
   $project_dev_regex = regsubst($project_dev_glob, /[?*]/, {'?' => '.', '*' => '.*' })

--- a/site/profile/templates/accounts/mkhome.sh.epp
+++ b/site/profile/templates/accounts/mkhome.sh.epp
@@ -4,6 +4,7 @@ grep --line-buffered -oP 'ADD dn=\"uid=\K([a-z0-9A-Z_]*)(?=,cn=users)' |
 while read USERNAME; do
 <% if $with_home { -%>
     USER_HOME="/mnt/home/$USERNAME"
+    sss_cache -u $USERNAME
     rsync -opg -r -u --chown=$USERNAME:$USERNAME --chmod=D700,F700 /etc/skel/ $USER_HOME
     restorecon -F -R $USER_HOME
 <% } -%>

--- a/site/profile/templates/accounts/mkhome.sh.epp
+++ b/site/profile/templates/accounts/mkhome.sh.epp
@@ -6,6 +6,7 @@ while read USERNAME; do
     rsync -opg -r -u --chown=$USERNAME:$USERNAME --chmod=D700,F700 /etc/skel/ $USER_HOME
     restorecon -F -R $USER_HOME
 
+<% if $with_scratch { -%>
     USER_SCRATCH="/scratch/$USERNAME"
     SERVER_SCRATCH="/mnt/$USER_SCRATCH"
     if [[ ! -d "$MOUNT_SCRATCH" ]]; then
@@ -15,4 +16,5 @@ while read USERNAME; do
         chmod 750 $SERVER_SCRATCH
         restorecon -F -R $SERVER_SCRATCH
     fi
+<% } -%>
 done

--- a/site/profile/templates/accounts/mkhome.sh.epp
+++ b/site/profile/templates/accounts/mkhome.sh.epp
@@ -3,21 +3,25 @@ tail -F /var/log/dirsrv/slapd-*/access |
 grep --line-buffered -oP 'ADD dn=\"uid=\K([a-z0-9A-Z_]*)(?=,cn=users)' |
 while read USERNAME; do
 <% if $with_home { -%>
-    USER_HOME="/mnt/home/$USERNAME"
     while ! sss_cache -u $USERNAME; do sleep 5; done
-    rsync -opg -r -u --chown=$USERNAME:$USERNAME --chmod=D700,F700 /etc/skel/ $USER_HOME
-    restorecon -F -R $USER_HOME
+    USER_HOME=$(getent passwd $USERNAME | cut -d: -f6)
+    MNT_USER_HOME="/mnt${USER_HOME}"
+    rsync -opg -r -u --chown=$USERNAME:$USERNAME --chmod=D700,F700 /etc/skel/ ${MNT_USER_HOME}
+    restorecon -F -R ${MNT_USER_HOME}
 <% } -%>
 
 <% if $with_scratch { -%>
-    USER_SCRATCH="/scratch/$USERNAME"
-    SERVER_SCRATCH="/mnt/$USER_SCRATCH"
-    if [[ ! -d "$MOUNT_SCRATCH" ]]; then
-        mkdir -p $SERVER_SCRATCH
-        ln -sfT $USER_SCRATCH "$USER_HOME/scratch"
-        chown -h $USERNAME:$USERNAME $SERVER_SCRATCH "$USER_HOME/scratch"
-        chmod 750 $SERVER_SCRATCH
-        restorecon -F -R $SERVER_SCRATCH
+    USER_SCRATCH="/scratch/${USERNAME}"
+    MNT_USER_SCRATCH="/mnt/${USER_SCRATCH}"
+    if [[ ! -d "${MNT_USER_SCRATCH}" ]]; then
+        mkdir -p ${MNT_USER_SCRATCH}
+<% if $with_home { -%>
+        ln -sfT ${USER_SCRATCH} "${USER_HOME}/scratch"
+        chown -h ${USERNAME}:${USERNAME} "${USER_HOME}/scratch"
+<% } -%>
+        chown -h ${USERNAME}:${USERNAME} ${MNT_USER_SCRATCH}
+        chmod 750 ${MNT_USER_SCRATCH}
+        restorecon -F -R ${MNT_USER_SCRATCH}
     fi
 <% } -%>
 done

--- a/site/profile/templates/accounts/mkhome.sh.epp
+++ b/site/profile/templates/accounts/mkhome.sh.epp
@@ -2,9 +2,11 @@
 tail -F /var/log/dirsrv/slapd-*/access |
 grep --line-buffered -oP 'ADD dn=\"uid=\K([a-z0-9A-Z_]*)(?=,cn=users)' |
 while read USERNAME; do
+<% if $with_home { -%>
     USER_HOME="/mnt/home/$USERNAME"
     rsync -opg -r -u --chown=$USERNAME:$USERNAME --chmod=D700,F700 /etc/skel/ $USER_HOME
     restorecon -F -R $USER_HOME
+<% } -%>
 
 <% if $with_scratch { -%>
     USER_SCRATCH="/scratch/$USERNAME"

--- a/site/profile/templates/accounts/mkhome.sh.epp
+++ b/site/profile/templates/accounts/mkhome.sh.epp
@@ -4,7 +4,7 @@ grep --line-buffered -oP 'ADD dn=\"uid=\K([a-z0-9A-Z_]*)(?=,cn=users)' |
 while read USERNAME; do
 <% if $with_home { -%>
     USER_HOME="/mnt/home/$USERNAME"
-    sss_cache -u $USERNAME
+    while ! sss_cache -u $USERNAME; do sleep 5; done
     rsync -opg -r -u --chown=$USERNAME:$USERNAME --chmod=D700,F700 /etc/skel/ $USER_HOME
     restorecon -F -R $USER_HOME
 <% } -%>

--- a/site/profile/templates/accounts/mkhome.sh.epp
+++ b/site/profile/templates/accounts/mkhome.sh.epp
@@ -3,7 +3,7 @@ tail -F /var/log/dirsrv/slapd-*/access |
 grep --line-buffered -oP 'ADD dn=\"uid=\K([a-z0-9A-Z_]*)(?=,cn=users)' |
 while read USERNAME; do
 <% if $with_home { -%>
-    while ! sss_cache -u $USERNAME; do sleep 5; done
+    while ! id $USERNAME; do sss_cache -u $USERNAME; sleep 5; done
     USER_HOME=$(getent passwd $USERNAME | cut -d: -f6)
     MNT_USER_HOME="/mnt${USER_HOME}"
     rsync -opg -r -u --chown=$USERNAME:$USERNAME --chmod=D700,F700 /etc/skel/ ${MNT_USER_HOME}

--- a/site/profile/templates/accounts/mkproject.sh.epp
+++ b/site/profile/templates/accounts/mkproject.sh.epp
@@ -56,11 +56,13 @@ while read CONN OP GROUP; do
         done
 
         # Then we create the project folder
-        mkdir -p "/mnt/project/$GID"
-        chown root:"$GROUP" "/mnt/project/$GID"
-        chmod 2770 "/mnt/project/$GID"
-        ln -sfT "/project/$GID" "/mnt/project/$GROUP"
-        restorecon -F -R /project/$GID /project/$GROUP
+        MNT_PROJECT_GID="/mnt/project/$GID"
+        MNT_PROJECT_GROUP="/mnt/project/$GROUP"
+        mkdir -p ${MNT_PROJECT_GID}
+        chown root:"$GROUP" ${MNT_PROJECT_GID}
+        chmod 2770 ${MNT_PROJECT_GID}
+        ln -sfT "/project/$GID" ${MNT_PROJECT_GROUP}
+        restorecon -F -R ${MNT_PROJECT_GID} ${MNT_PROJECT_GROUP}
 <% } %>
     elif [[ "$OP" == "MOD" ]]; then
         # A group has been modified
@@ -85,7 +87,7 @@ while read CONN OP GROUP; do
                 chown "${USERNAME}" "${PRO_USER}"
                 chmod 0755 "${USER_HOME}/projects"
                 chmod 2700 "${PRO_USER}"
-                restorecon -F -R "/mnt/project/${GROUP}/${USERNAME}"
+                restorecon -F -R "${MNT_PROJECT}/${USERNAME}"
             done
 <% } -%>
             /opt/software/slurm/bin/sacctmgr add user ${USERNAMES} Account=${GROUP} -i

--- a/site/profile/templates/accounts/mkproject.sh.epp
+++ b/site/profile/templates/accounts/mkproject.sh.epp
@@ -45,7 +45,7 @@ while read CONN OP GROUP; do
         # A new group has been created
         # We create the associated account in slurm
         /opt/software/slurm/bin/sacctmgr add account $GROUP -i
-
+<% if $with_folder { %>
         # We clean the SSSD cache before recovering the group GID.
         # This is in case the group existed before with a different gid.
         GID=""
@@ -61,7 +61,7 @@ while read CONN OP GROUP; do
         chmod 2770 "/mnt/project/$GID"
         ln -sfT "/project/$GID" "/mnt/project/$GROUP"
         restorecon -F -R /project/$GID /project/$GROUP
-
+<% } %>
     elif [[ "$OP" == "MOD" ]]; then
         # A group has been modified
         # We grep the log for all operations related to request $CONN that contain a uid
@@ -87,6 +87,7 @@ while read CONN OP GROUP; do
                 chmod 2700 "${PRO_USER}"
                 restorecon -F -R "/mnt/project/${GROUP}/${USERNAME}"
             done
+<% } -%>
             /opt/software/slurm/bin/sacctmgr add user ${USERNAMES} Account=${GROUP} -i
         else
             # If group has been modified but no uid were found in the log, it means
@@ -97,10 +98,12 @@ while read CONN OP GROUP; do
             USERNAMES=$(comm -2 -3 <(echo "$SLURM_ACCOUNT") <(echo "$USER_GROUP"))
             if [[ ! -z "$USERNAMES" ]]; then
                 /opt/software/slurm/bin/sacctmgr remove user $USERNAMES Account=${GROUP} -i
+<% if $with_folder { -%>
                 for USERNAME in $USERNAMES; do
                     USER_HOME="/mnt/home/$USERNAME"
                     rm "$USER_HOME/projects/$GROUP"
                 done
+<% } -%>
             fi
         fi
     elif [[ "$OP" == "DEL" ]]; then
@@ -110,10 +113,12 @@ while read CONN OP GROUP; do
         USERNAMES=$(/opt/software/slurm/bin/sacctmgr list assoc account=$GROUP format=user --noheader -p | cut -d'|' -f1 | awk NF | sort)
         if [[ ! -z "$USERNAMES" ]]; then
             /opt/software/slurm/bin/sacctmgr remove user $USERNAMES Account=${GROUP} -i
+<% if $with_folder { -%>
             for USERNAME in $USERNAMES; do
                 USER_HOME="/mnt/home/$USERNAME"
                 rm "$USER_HOME/projects/$GROUP"
             done
+<% } -%>
         fi
     fi
 

--- a/site/profile/templates/slurm/slurm.conf.epp
+++ b/site/profile/templates/slurm/slurm.conf.epp
@@ -65,7 +65,7 @@ AccountingStorageHost={{ .Node }}
 {{ if service "slurmdbd" -}}
 AccountingStorageType=accounting_storage/slurmdbd
 AccountingStorageTRES=gres/gpu,cpu,mem
-#AccountingStorageEnforce=limits
+AccountingStorageEnforce=associations
 JobAcctGatherType=jobacct_gather/cgroup
 JobAcctGatherFrequency=task=30
 JobAcctGatherParams=NoOverMemoryKill,UsePSS


### PR DESCRIPTION
This PR refactors how the NFS server creates its exports and how the NFS clients find out about available exports. Because `project` and `scratch` volumes were mounted at the root of the NFS server and `home` was mounted in `/mnt`, the refactoring had to move `project` and `scratch` to `/mnt`.

This change of path made me relook at the daemon code and I figure `home`, `project` and `scratch` could be made optional. If no volume with the corresponding name is created in the Terraform `main.tf`, Puppet will no longer tries to format the volume, export nor try to create users' folder in these mounts.

By refactoring the NFS server export code, it opens the door for users to create other NFS exported volumes, named how ever they like. For example, if one add `software = { size = 100 }` to the nfs map in `main.tf`, it will automatically translates into a volume of 100GB being exported on login and compute nodes as `/software`.

Final remotely related change, while working with the project creation daemon, I realized the Slurm configuration in MC accepted any combination of characters for an account when submitting jobs. To restrict to valid account associations, this PR sets `AccountingStorageEnforce` to `associations`. This has the unfortunate effect of disabling the account `centos` from submitting jobs, but that's for the better I think.