### PR TITLE
Configure resolv.conf with NetworkManager

### DIFF
--- a/site/profile/lib/facter/nameservers.rb
+++ b/site/profile/lib/facter/nameservers.rb
@@ -1,0 +1,7 @@
+require 'resolv'
+
+Facter.add("nameservers") do
+  setcode do
+    Resolv::DNS::Config.default_config_hash[:nameserver]
+  end
+end

--- a/site/profile/templates/freeipa/zzz-puppet.conf.epp
+++ b/site/profile/templates/freeipa/zzz-puppet.conf.epp
@@ -1,0 +1,10 @@
+# File managed by puppet
+[main]
+dns=default
+
+[global-dns]
+searches=<%= $int_domain_name %>
+
+[global-dns-domain-*]
+servers=<%= join($nameservers, ',') -%>
+


### PR DESCRIPTION
When the search line was missing from resolv.conf, puppet file_line was appending the line at the end of the file, preventing dns resolving to work correctly. We will let NetworkManager do its thing to configure resolv.conf and simply add a file to instruct the search domain and the new nameservers to NetworkManager.

Fix #151, #152.