### PR TITLE
Update compute canada software stack to 2020

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,8 +34,7 @@ variables for each profile.
 | ------------------------------------------------ | :------------ | :--------------------------------------------- | -------------------------------------------------------------------- |
 | `profile::cvmfs::client::quota_limit`            | Integer       | Instance local cache directory soft quota (MB) | 4096                                                                 |
 | `profile::cvmfs::client::repositories`           | Array[String] | List of CVMFS repositories to mount            | `['cvmfs-config.computecanada.ca', 'soft.computecanada.ca']`         |
-| `profile::cvmfs::client::lmod_default_modules`   | Array[String] | List of lmod default modules                   | `['nixpkgs/16.09', 'imkl/2018.3.222', 'gcc/7.3.0', 'openmpi/3.1.2']` |
-
+| `profile::cvmfs::client::lmod_default_modules`   | Array[String] | List of lmod default modules                   | `['gentoo/2020', 'imkl/2020.1.217', 'gcc/9.3.0', 'openmpi/4.0.3']` |
 
 ## profile::fail2ban
 

--- a/data/common.yaml
+++ b/data/common.yaml
@@ -59,7 +59,7 @@ jupyterhub::jupyterhub_config_hash:
 
   SbatchForm:
     ui:
-      choices: ['notebook', 'lab', 'terminal', 'code-server', 'rstudio', 'desktop']
+      choices: ['notebook', 'lab', 'terminal', 'code-server', 'desktop']
       def: 'lab'
 
 squid::cache_mem: "256 MB"

--- a/data/os/RedHat/7.yaml
+++ b/data/os/RedHat/7.yaml
@@ -13,7 +13,7 @@ profile::gpu::install::passthrough::packages:
     - nvidia-xconfig-latest-dkms
     - kmod-nvidia-latest-dkms
 profile::cvmfs::client::lmod_default_modules:
-    - nixpkgs/16.09
-    - imkl/2018.3.222
-    - gcc/7.3.0
-    - openmpi/3.1.2
+    - gentoo/2020
+    - imkl/2020.1.217
+    - gcc/9.3.0
+    - openmpi/4.0.3

--- a/data/software_stack/computecanada.yaml
+++ b/data/software_stack/computecanada.yaml
@@ -1,4 +1,4 @@
-jupyterhub::kernel::venv::python: /cvmfs/soft.computecanada.ca/easybuild/software/2020/avx2/Core/python/3.9/bin/python
+jupyterhub::kernel::venv::python: /cvmfs/soft.computecanada.ca/easybuild/software/2020/avx2/Core/python/3.9.6/bin/python
 jupyterhub::kernel::venv::pip_environment:
   PYTHONPATH: "/cvmfs/soft.computecanada.ca/custom/python/site-packages"
   PIP_CONFIG_FILE: "/cvmfs/soft.computecanada.ca/config/python/pip-avx2-gentoo.conf"

--- a/data/software_stack/computecanada.yaml
+++ b/data/software_stack/computecanada.yaml
@@ -1,7 +1,7 @@
-jupyterhub::kernel::venv::python: /cvmfs/soft.computecanada.ca/easybuild/software/2017/Core/python/3.7.4/bin/python
+jupyterhub::kernel::venv::python: /cvmfs/soft.computecanada.ca/easybuild/software/2020/avx2/Core/python/3.9/bin/python
 jupyterhub::kernel::venv::pip_environment:
   PYTHONPATH: "/cvmfs/soft.computecanada.ca/custom/python/site-packages"
-  PIP_CONFIG_FILE: "/cvmfs/soft.computecanada.ca/config/python/pip-avx2.conf"
+  PIP_CONFIG_FILE: "/cvmfs/soft.computecanada.ca/config/python/pip-avx2-gentoo.conf"
 
 jupyterhub::jupyterhub_config_hash:
   SlurmFormSpawner:


### PR DESCRIPTION
Used to be 2020 for CentOS 8 only, not it is also the default for CentOS 7.