### PR TITLE
Add missing rpm for nvidia gpu passthrough setup in CentOS 8

### DIFF
--- a/data/os/RedHat/8.yaml
+++ b/data/os/RedHat/8.yaml
@@ -9,6 +9,7 @@ profile::gpu::install::passthrough::packages:
     - nvidia-modprobe
     - nvidia-xconfig
     - kmod-nvidia-latest-dkms
+    - nvidia-persistenced
 profile::cvmfs::client::lmod_default_modules:
     - gentoo/2020
     - imkl/2020.1.217


### PR DESCRIPTION
Fix #159 