### PR TITLE
Remove dhclient removal in centos 8

### DIFF
--- a/site/profile/manifests/freeipa.pp
+++ b/site/profile/manifests/freeipa.pp
@@ -25,12 +25,6 @@ class profile::freeipa::base (
     require => Package['NetworkManager'],
   }
 
-  if dig($::facts, 'os', 'release', 'major') == '8' {
-    package { 'dhclient':
-      ensure => absent,
-    }
-  }
-
   service { 'systemd-logind':
     ensure => running,
     enable => true


### PR DESCRIPTION
It is now a dependency of cloud-init for some reason, and it does not harm to leave it there.

Closes #166 