### PR TITLE
Put lmod_default_modules in computecanada.yaml

### DIFF
--- a/data/os/RedHat/7.yaml
+++ b/data/os/RedHat/7.yaml
@@ -12,8 +12,4 @@ profile::gpu::install::passthrough::packages:
     - nvidia-persistenced-latest-dkms
     - nvidia-xconfig-latest-dkms
     - kmod-nvidia-latest-dkms
-profile::cvmfs::client::lmod_default_modules:
-    - gentoo/2020
-    - imkl/2020.1.217
-    - gcc/9.3.0
-    - openmpi/4.0.3
+

--- a/data/os/RedHat/8.yaml
+++ b/data/os/RedHat/8.yaml
@@ -10,8 +10,3 @@ profile::gpu::install::passthrough::packages:
     - nvidia-xconfig
     - kmod-nvidia-latest-dkms
     - nvidia-persistenced
-profile::cvmfs::client::lmod_default_modules:
-    - gentoo/2020
-    - imkl/2020.1.217
-    - gcc/9.3.0
-    - openmpi/4.0.3

--- a/data/software_stack/computecanada.yaml
+++ b/data/software_stack/computecanada.yaml
@@ -7,7 +7,7 @@ jupyterhub::jupyterhub_config_hash:
   SlurmFormSpawner:
     ui_args:
       rstudio:
-        modules: ['gcc/7.3.0', 'rstudio-server']
+        modules: ['gcc/9.3.0', 'rstudio-server']
       code-server:
         modules: ['code-server']
 
@@ -24,3 +24,9 @@ profile::squid::server::cvmfs_acl_regex:
   - '^(cvmfs-.*\.genap\.ca)$'
 
 profile::gpu::install::lib_symlink_path: '/usr/lib64/nvidia'
+
+profile::cvmfs::client::lmod_default_modules:
+    - gentoo/2020
+    - imkl/2020.1.217
+    - gcc/9.3.0
+    - openmpi/4.0.3


### PR DESCRIPTION
Previously in data/os/RedHat because CentOS 7 and 8 had a different list of default modules.