### PR TITLE
Set MemSpecLimit in slurm.conf and allow configuration using hieradata

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,7 @@ variables for each profile.
 | `profile::slurm::base::cluster_name`  | String  | Name of the cluster                                                     |          |
 | `profile::slurm::base::munge_key`     | String  | Base64 encoded Munge key                                                |          |
 | `profile::slurm::base::slurm_version`  | Enum[19.05, 20.11, 21.08]  | Slurm version to install                            | 21.08    |
+| `profile::slurm::base::os_reserved_memory`  | Integer  | Quantity of memory in MB reserved for the operating system on the compute nodes | 512 |
 | `profile::slurm::base::enable_x11_forwarding`  | Boolean  | Enable Slurm's built-in X11 forwarding capabilities           | `true`   |
 | `profile::slurm::accounting::password` | String  | Password used by for SlurmDBD to connect to MariaDB                    |          |
 | `profile::slurm::accounting::dbd_port` | Integer | SlurmDBD service listening port                                        |          |

--- a/data/common.yaml
+++ b/data/common.yaml
@@ -90,6 +90,7 @@ profile::reverse_proxy::ipa_subdomain: ipa
 profile::reverse_proxy::mokey_subdomain: mokey
 
 profile::slurm::base::slurm_version: '21.08'
+profile::slurm::base::os_reserved_memory: 512
 
 prometheus::storage_retention: '48h'
 prometheus::storage_retention_size: '5GB'

--- a/site/profile/manifests/base.pp
+++ b/site/profile/manifests/base.pp
@@ -159,7 +159,7 @@ class profile::base (
     ensure => absent
   }
 
-  $mc_plugins_version = '1.0.3'
+  $mc_plugins_version = '1.0.5'
   package { 'magic_castle-plugins':
     ensure   => 'latest',
     name     => 'magic_castle-plugins',

--- a/site/profile/manifests/slurm.pp
+++ b/site/profile/manifests/slurm.pp
@@ -4,10 +4,13 @@
 # on all types of nodes.
 # @param cluster_name Specifies the name of the cluster as it appears in slurm.conf
 # @param munge_key Specifies the munge secret key that allows slurm nodes to communicate
+# @param slurm_version Specifies which version of Slurm to install
+# @param os_reserved_memory Specifies the amount of memory reserved for the operating system in compute node
 class profile::slurm::base (
   String $cluster_name,
   String $munge_key,
   Enum['19.05', '20.11', '21.08'] $slurm_version,
+  Integer $os_reserved_memory,
   Boolean $force_slurm_in_path = false,
   Boolean $enable_x11_forwarding = true,
 )
@@ -430,14 +433,16 @@ class profile::slurm::node {
   }
 
   $real_memory = $facts['memory']['system']['total_bytes'] / (1024 * 1024)
+  $os_reserved_memory = lookup('profile::slurm::base::os_reserved_memory')
   consul::service { 'slurmd':
     port    => 6818,
     require => Tcp_conn_validator['consul'],
     token   => lookup('profile::consul::acl_api_token'),
     meta    => {
-      cpus       => String($facts['processors']['count']),
-      realmemory => String($real_memory),
-      gpus       => String($facts['nvidia_gpu_count']),
+      cpus         => String($facts['processors']['count']),
+      realmemory   => String($real_memory),
+      gpus         => String($facts['nvidia_gpu_count']),
+      memspeclimit => String($os_reserved_memory),
     },
   }
 


### PR DESCRIPTION
Currently, Slurm can allocate the entirety of RAM available on a compute node. This can lead to job using all the memory available on a compute node which then leads the oom killer to kill random processes, putting the node in a weird state.

To avoid that, we define a minimum quantity of memory that cannot be allocated by Slurm. To remove the limit, the parameter can be set to 0.