### PR TITLE
Slurm accounting configuration from flat file

### DIFF
--- a/site/profile/templates/slurm/sacct.cfg.epp
+++ b/site/profile/templates/slurm/sacct.cfg.epp
@@ -1,0 +1,17 @@
+#
+Cluster - '<%= $cluster %>':<%= join($cluster_options.map|$key, $value| { "${key}=${value}" },  ':')%>
+Parent - root
+User - root:AdminLevel=Administrator
+<% $admins.each |$username| { -%>
+User - <%= $username %>:AdminLevel=Administrator
+<% } -%>
+
+<% $accounts.each |$key, $values| { -%>
+Account - <%= $key %>:<%= join($values.map|$key, $value| { "${key}=${value}" },  ':')%>
+<% } -%>
+<% $users.each |$user, $accounts| { -%>
+<% $accounts.each |$index, $account| { -%>
+Parent - <%= $account %>
+User - <%= $user %><% if $index == 0 { %>:DefaultAccount=<%= $account %><% } %>
+<% } -%>
+<% } -%>


### PR DESCRIPTION
This PR allows the definition of Slurm accounting using hieradata throught the creation of a flat file that is than loaded with `sacctmgr`.