### PR TITLE
Add letsencrypt facts to disable vhosts that require SSL certificates when the latter are missing

### DIFF
--- a/site/profile/facts.d/letsencrypt.sh
+++ b/site/profile/facts.d/letsencrypt.sh
@@ -10,9 +10,11 @@ if [ -d /etc/letsencrypt ]; then
         echo "    cert:" $(test -e $path/cert.pem && echo true || echo false)
         echo "    privkey:" $(test -e $path/privkey.pem && echo true || echo false)
         echo "    chain:" $(test -e $path/chain.pem && echo true || echo false)
-        echo "    startdate:" $(openssl x509 -in $path/fullchain.pem -startdate -noout | cut -d= -f2)
-        echo "    enddate:" $(openssl x509 -in $path/fullchain.pem -enddate -noout | cut -d= -f2)
-        echo "    willexpire:" $(openssl x509 -in $path/fullchain.pem -checkend 1800 | grep -q "will expire" && echo true || echo false)
+        if [ -e $path/fullchain.pem ]; then
+            echo "    startdate:" $(openssl x509 -in $path/fullchain.pem -startdate -noout | cut -d= -f2)
+            echo "    enddate:" $(openssl x509 -in $path/fullchain.pem -enddate -noout | cut -d= -f2)
+            echo "    willexpire:" $(openssl x509 -in $path/fullchain.pem -checkend 1800 | grep -q "will expire" && echo true || echo false)
+        fi
     done
 else
     echo "letsencrypt: {}"

--- a/site/profile/facts.d/letsencrypt.sh
+++ b/site/profile/facts.d/letsencrypt.sh
@@ -1,0 +1,14 @@
+#!/bin/sh
+
+echo "---"
+echo "letsencrypt:"
+for path in /etc/letsencrypt/live/*; do
+    domain=$(basename $path)
+    echo "  $domain:"
+    echo "    fullchain: " $(test -e $path/fullchain.pem && echo true || echo false)
+    echo "    cert: " $(test -e $path/cert.pem && echo true || echo false)
+    echo "    privkey: " $(test -e $path/privkey.pem && echo true || echo false)
+    echo "    chain: " $(test -e $path/chain.pem && echo true || echo false)
+    echo "    startdate: " $(openssl x509 -in $path/fullchain.pem -startdate | cut -d= -f2)
+    echo "    enddate: " $(openssl x509 -in $path/fullchain.pem -enddate | cut -d= -f2)
+done

--- a/site/profile/facts.d/letsencrypt.sh
+++ b/site/profile/facts.d/letsencrypt.sh
@@ -1,14 +1,19 @@
 #!/bin/sh
 
 echo "---"
-echo "letsencrypt:"
-for path in /etc/letsencrypt/live/*; do
-    domain=$(basename $path)
-    echo "  $domain:"
-    echo "    fullchain: " $(test -e $path/fullchain.pem && echo true || echo false)
-    echo "    cert: " $(test -e $path/cert.pem && echo true || echo false)
-    echo "    privkey: " $(test -e $path/privkey.pem && echo true || echo false)
-    echo "    chain: " $(test -e $path/chain.pem && echo true || echo false)
-    echo "    startdate: " $(openssl x509 -in $path/fullchain.pem -startdate | cut -d= -f2)
-    echo "    enddate: " $(openssl x509 -in $path/fullchain.pem -enddate | cut -d= -f2)
-done
+if [ -d /etc/letsencrypt ]; then
+    echo "letsencrypt:"
+    for path in $(ls /etc/letsencrypt/live); do
+        domain=$(basename $path)
+        echo "  $domain:"
+        echo "    fullchain:" $(test -e $path/fullchain.pem && echo true || echo false)
+        echo "    cert:" $(test -e $path/cert.pem && echo true || echo false)
+        echo "    privkey:" $(test -e $path/privkey.pem && echo true || echo false)
+        echo "    chain:" $(test -e $path/chain.pem && echo true || echo false)
+        echo "    startdate:" $(openssl x509 -in $path/fullchain.pem -startdate -noout | cut -d= -f2)
+        echo "    enddate:" $(openssl x509 -in $path/fullchain.pem -enddate -noout | cut -d= -f2)
+        echo "    willexpire:" $(openssl x509 -in $path/fullchain.pem -checkend 1800 | grep -q "will expire" && echo true || echo false)
+    done
+else
+    echo "letsencrypt: {}"
+fi

--- a/site/profile/facts.d/letsencrypt.sh
+++ b/site/profile/facts.d/letsencrypt.sh
@@ -3,8 +3,8 @@
 echo "---"
 if [ -d /etc/letsencrypt ]; then
     echo "letsencrypt:"
-    for path in $(ls /etc/letsencrypt/live); do
-        domain=$(basename $path)
+    for domain in $(ls /etc/letsencrypt/live); do
+        path=/etc/letsencrypt/live/$domain
         echo "  $domain:"
         echo "    fullchain:" $(test -e $path/fullchain.pem && echo true || echo false)
         echo "    cert:" $(test -e $path/cert.pem && echo true || echo false)

--- a/site/profile/manifests/globus.pp
+++ b/site/profile/manifests/globus.pp
@@ -18,10 +18,19 @@ class profile::globus::base (String $globus_user = '', String $globus_password =
   }
 
   if $globus_user != '' and $globus_password != '' {
+    if dig($::facts, 'os', 'release', 'major') == '7' {
+      $required_pkg = [
+        Package['yum-plugin-priorities'],
+        Package['globus-connect-server-repo']
+      ]
+    } else {
+      $required_pkg = [
+        Package['globus-connect-server-repo']
+      ]
+    }
     package { 'globus-connect-server':
       ensure  => 'installed',
-      require => [Package['yum-plugin-priorities'],
-                  Package['globus-connect-server-repo']]
+      require => $required_pkg,
     }
 
     if $privkey_exists and $fullchain_exists {

--- a/site/profile/manifests/globus.pp
+++ b/site/profile/manifests/globus.pp
@@ -12,11 +12,9 @@ class profile::globus::base (String $globus_user = '', String $globus_password =
   if $domain_name in $::facts['letsencrypt'] {
     $privkey_exists = $::facts['letsencrypt'][$domain_name]['privkey']
     $fullchain_exists = $::facts['letsencrypt'][$domain_name]['fullchain']
-    $willexpire = $::facts['letsencrypt'][$domain_name]['willexpire']
   } else {
     $privkey_exists = false
     $fullchain_exists = false
-    $willexpire = false
   }
 
   if $globus_user != '' and $globus_password != '' {
@@ -26,7 +24,7 @@ class profile::globus::base (String $globus_user = '', String $globus_password =
                   Package['globus-connect-server-repo']]
     }
 
-    if $privkey_exists and $fullchain_exists and !$willexpire {
+    if $privkey_exists and $fullchain_exists {
       apache::vhost { "dtn.${domain_name}":
         port                        => '443',
         docroot                     => false,

--- a/site/profile/manifests/globus.pp
+++ b/site/profile/manifests/globus.pp
@@ -21,11 +21,13 @@ class profile::globus::base (String $globus_user = '', String $globus_password =
     if dig($::facts, 'os', 'release', 'major') == '7' {
       $required_pkg = [
         Package['yum-plugin-priorities'],
-        Package['globus-connect-server-repo']
+        Package['globus-connect-server-repo'],
+        Yumrepo['epel'],
       ]
     } else {
       $required_pkg = [
-        Package['globus-connect-server-repo']
+        Package['globus-connect-server-repo'],
+        Yumrepo['epel'],
       ]
     }
     package { 'globus-connect-server':

--- a/site/profile/manifests/globus.pp
+++ b/site/profile/manifests/globus.pp
@@ -81,10 +81,11 @@ class profile::globus::base (String $globus_user = '', String $globus_password =
         ssl_cert                    => "/etc/letsencrypt/live/${domain_name}/fullchain.pem",
         ssl_key                     => "/etc/letsencrypt/live/${domain_name}/privkey.pem",
       }
-      file { '/etc/globus-connect-server.conf':
-        ensure  => 'present',
-        content => epp('profile/globus/globus-connect-server.conf', { 'hostname' => "dtn.${domain_name}" }),
-      }
+    }
+
+    file { '/etc/globus-connect-server.conf':
+      ensure  => 'present',
+      content => epp('profile/globus/globus-connect-server.conf', { 'hostname' => "dtn.${domain_name}" }),
     }
 
     firewall { '100 Globus connect server - globus.org':


### PR DESCRIPTION
Currently, Magic Castle clusters that are spawned without DNS records have their puppet logs filled with errors about httpd not being able to start because of error in its configuration file.

This PR introduce a `letsencrypt.sh` script that provides facts about domains with SSL certificates available on the instance. In `profile::reverse_proxy` we then use these facts to verify the SSL certificate for the provided domain name is available. If it is, the vhosts are configured. If the certificate is missing, a warning message is put in the puppet journal.