### PR TITLE
Update source of cvmfs-repo

### DIFF
--- a/site/profile/manifests/cvmfs.pp
+++ b/site/profile/manifests/cvmfs.pp
@@ -7,8 +7,8 @@ class profile::cvmfs::client(
   package { 'cvmfs-repo':
     ensure   => 'installed',
     provider => 'rpm',
-    name     => 'cvmfs-release-2-6.noarch',
-    source   => 'https://ecsft.cern.ch/dist/cvmfs/cvmfs-release/cvmfs-release-latest.noarch.rpm'
+    name     => 'cvmfs-release-3-2.noarch',
+    source   => 'https://ecsft.cern.ch/dist/cvmfs/cvmfs-release/cvmfs-release-3-2.noarch.rpm',
   }
 
   if $::software_stack == 'eessi' {


### PR DESCRIPTION
cvmfs-release-latest repo is no longer version "2-6" and the name mismatch breaks a resource dependency chain on the compute node.