### PR TITLE
Put consul_template::watch of slurm-consul in slurm::base

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Changed
 - Fixed mkhome daemon to retry initial rsync of a LDAP user's home (#218, #219)
 - Fixed LDAP TLS certificate to add ipa subdomain (#215)
+- Moved `consul_template::watch` of `slurm-consul.conf` in `slurm::base` (#221, #222)
 
 ### Added
 - Activated SSH hostbased authentication on compute nodes, from login and compute nodes. (#5, #217)


### PR DESCRIPTION
Combine `cond_restart_slurmctld` and `cond_restart_slurmd` in a single file to allow the definition of a single `consul_watch::template` and allow instantiation of an instance with both `login` and `mgmt` tags.