### PR TITLE
Fix /etc/hosts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Fixed mkhome daemon to retry initial rsync of a LDAP user's home (#218, #219)
 - Fixed LDAP TLS certificate to add ipa subdomain (#215)
 - Moved `consul_template::watch` of `slurm-consul.conf` in `slurm::base` (#221, #222)
+- Consolidated generation of `/etc/hosts` in a single class `profile::base` (#221, #225)
 
 ### Added
 - Activated SSH hostbased authentication on compute nodes, from login and compute nodes. (#5, #217)


### PR DESCRIPTION
Define all hosts from /etc/hosts in profile::base to avoid problem with freeipa::server defining its own host.