### PR TITLE
Add mising slurm::submitter class to jupyterhub::hub

### DIFF
--- a/site/profile/manifests/jupyterhub.pp
+++ b/site/profile/manifests/jupyterhub.pp
@@ -14,6 +14,7 @@ class profile::jupyterhub::hub {
       }
     ),
   }
+  include profile::slurm::submitter
 }
 
 class profile::jupyterhub::node {


### PR DESCRIPTION
When jupyterhub was not instantiated on a login node, it was missing the slurm binaries which are required by the SlurmSpawner.

Closes #227 