### PR TITLE
Fix identification of local interface to setup networking

### DIFF
--- a/site/profile/functions/getcidr.pp
+++ b/site/profile/functions/getcidr.pp
@@ -1,5 +1,5 @@
 function profile::getcidr() >> String {
-  $interface = $networking['primary']
+  $interface = profile::getlocalinterface()
   $masklen = netmask_to_masklen(profile::getnetmask())
   $network = $networking['interfaces'][$interface]['network']
   "${network}/${masklen}"

--- a/site/profile/functions/getlocalinterface.pp
+++ b/site/profile/functions/getlocalinterface.pp
@@ -1,0 +1,8 @@
+function profile::getlocalinterface() >> String {
+  $local_ip = lookup("terraform.instances.${facts['networking']['hostname']}.local_ip")
+  $interfaces = keys($facts['networking']['interfaces'])
+  $search = $interfaces.filter | $interface | {
+    $facts['networking']['interfaces'][$interface]['ip'] == $local_ip
+  }
+  $search[0]
+}

--- a/site/profile/functions/getnetmask.pp
+++ b/site/profile/functions/getnetmask.pp
@@ -3,7 +3,7 @@ function profile::getnetmask() >> String {
     # GCP instances netmask is set to /32 but the network netmask is available
     $netmask = $gce['instance']['networkInterfaces'][0]['subnetmask']
   } else {
-    $interface = $networking['primary']
+    $interface = profile::getlocalinterface()
     $netmask = $networking['interfaces'][$interface]['netmask']
   }
   $netmask

--- a/site/profile/functions/getptrrecord.pp
+++ b/site/profile/functions/getptrrecord.pp
@@ -1,5 +1,5 @@
 function profile::getptrrecord() >> String {
-  $interface = $networking['primary']
+  $interface = profile::getlocalinterface()
   $ip = $networking['interfaces'][$interface]['ip']
   $ip_list = split($ip, '[.]')
   $netmask_list = split(profile::getnetmask(), '[.]')

--- a/site/profile/functions/getreversezone.pp
+++ b/site/profile/functions/getreversezone.pp
@@ -1,5 +1,5 @@
 function profile::getreversezone() >> String {
-  $interface = $networking['primary']
+  $interface = profile::getlocalinterface()
   $network = $networking['interfaces'][$interface]['network']
   $network_list = split($network, '[.]')
   $netmask_list = split(profile::getnetmask(), '[.]')

--- a/site/profile/manifests/base.pp
+++ b/site/profile/manifests/base.pp
@@ -11,7 +11,7 @@ class profile::base (
   $int_domain_name = "int.${domain_name}"
   $hostname = $facts['networking']['hostname']
   $fqdn = "${hostname}.${int_domain_name}"
-  $interface = $facts['networking']['primary']
+  $interface = profile::getlocalinterface()
   $ipaddress = $facts['networking']['interfaces'][$interface]['ip']
 
   file { '/etc/magic-castle-release':

--- a/site/profile/manifests/consul.pp
+++ b/site/profile/manifests/consul.pp
@@ -1,5 +1,5 @@
 class profile::consul::server {
-  $interface = $facts['networking']['primary']
+  $interface = profile::getlocalinterface()
   $ipaddress = $facts['networking']['interfaces'][$interface]['ip']
 
   class { 'consul':
@@ -35,7 +35,7 @@ class profile::consul::server {
 }
 
 class profile::consul::client (String $server_ip) {
-  $interface = $facts['networking']['primary']
+  $interface = profile::getlocalinterface()
   $ipaddress = $facts['networking']['interfaces'][$interface]['ip']
 
   class { 'consul':

--- a/site/profile/manifests/freeipa.pp
+++ b/site/profile/manifests/freeipa.pp
@@ -39,7 +39,7 @@ class profile::freeipa::client (String $server_ip) {
   $admin_password = lookup('profile::freeipa::server::admin_password')
   $fqdn = "${facts['networking']['hostname']}.${int_domain_name}"
   $realm = upcase($int_domain_name)
-  $interface = $facts['networking']['primary']
+  $interface = profile::getlocalinterface()
   $ipaddress = $facts['networking']['interfaces'][$interface]['ip']
 
   file { '/etc/NetworkManager/conf.d/zzz-puppet.conf':
@@ -209,7 +209,7 @@ class profile::freeipa::server (
   $fqdn = "${facts['networking']['hostname']}.${int_domain_name}"
   $reverse_zone = profile::getreversezone()
 
-  $interface = $facts['networking']['primary']
+  $interface = profile::getlocalinterface()
   $ipaddress = $facts['networking']['interfaces'][$interface]['ip']
 
   $idstart = Integer($facts['uid_max']) + 1


### PR DESCRIPTION
We cannot simply use the primary interface has defined by Puppet because in the case of OVH, it can be the public network interface. We therefore instead use the local ip address provided in Terraform data to identify the corresponding networking interface name then we can use Puppet facts.