### PR TITLE
Add patching of FreeIPA dna plugin initialization issue

### DIFF
--- a/site/profile/files/freeipa/27e9181bdc684915a7f9f15631f4c3dd6ac5f884.patch
+++ b/site/profile/files/freeipa/27e9181bdc684915a7f9f15631f4c3dd6ac5f884.patch
@@ -1,0 +1,36 @@
+From 27e9181bdc684915a7f9f15631f4c3dd6ac5f884 Mon Sep 17 00:00:00 2001
+From: Christian Heimes <cheimes@redhat.com>
+Date: Apr 18 2023 10:13:47 +0000
+Subject: Speed up installer by restarting DS after DNA plugin
+
+
+DS does not enable plugins unless nsslapd-dynamic-plugins is enabled or
+DS is restarted. The DNA plugin creates its configuration entries with
+some delay after the plugin is enabled.
+
+DS is now restarted after the DNA plugin is enabled so it can create the
+entries while Dogtag and the rest of the system is installing. The
+updater `update_dna_shared_config` no longer blocks and waits for two
+times 60 seconds for `posix-ids` and `subordinate-ids`.
+
+Fixes: https://pagure.io/freeipa/issue/9358
+Signed-off-by: Christian Heimes <cheimes@redhat.com>
+Reviewed-By: Rob Crittenden <rcritten@redhat.com>
+
+---
+
+diff --git a/ipaserver/install/dsinstance.py b/ipaserver/install/dsinstance.py
+index 157e21e..cbacfae 100644
+--- a/ipaserver/install/dsinstance.py
++++ b/ipaserver/install/dsinstance.py
+@@ -269,6 +269,9 @@ class DsInstance(service.Service):
+         self.step("activating extdom plugin", self._add_extdom_plugin)
+ 
+         self.step("configuring directory to start on boot", self.__enable)
++        # restart to enable plugins
++        # speeds up creation of DNA plugin entries in cn=dna,cn=ipa,cn=etc
++        self.step("restarting directory server", self.__restart_instance)
+ 
+     def init_info(self, realm_name, fqdn, domain_name, dm_password,
+                   subject_base, ca_subject,
+

--- a/site/profile/manifests/freeipa.pp
+++ b/site/profile/manifests/freeipa.pp
@@ -207,6 +207,27 @@ class profile::freeipa::server (
     ensure => 'installed',
   }
 
+  # Fix FreeIPA issue adding 2 minutes of wait time for nothing
+  # https://pagure.io/freeipa/issue/9358
+  # TODO: remove this patch once FreeIPA is released with the patch
+  ensure_packages(['patch'], { ensure => 'present' })
+  $python_version = lookup('os::redhat::python3::version')
+  file { 'freeipa_27e9181bdc.patch':
+    path   => "/usr/lib/python${python_version}/site-packages/freeipa_27e9181bdc.patch",
+    source => 'puppet:///modules/profile/freeipa/27e9181bdc684915a7f9f15631f4c3dd6ac5f884.patch',
+  }
+  exec { 'patch -p1 -r - --forward --quiet < freeipa_27e9181bdc.patch':
+    cwd         => "/usr/lib/python${python_version}/site-packages",
+    path        => ['/usr/bin', '/bin'],
+    subscribe   => [
+      File['freeipa_27e9181bdc.patch'],
+      Package['ipa-server-dns'],
+    ],
+    refreshonly => true,
+    before      => Exec['ipa-install'],
+    returns     => [0, 1],
+  }
+
   $int_domain_name = "int.${domain_name}"
   $realm = upcase($int_domain_name)
   $fqdn = "${facts['networking']['hostname']}.${int_domain_name}"


### PR DESCRIPTION
Without the patch that should be part of next FreeIPA release, it takes ipa-server-install 2 extra minutes to install for nothing.