### PR TITLE
Adjust user limits on compute node

### DIFF
--- a/Puppetfile
+++ b/Puppetfile
@@ -34,6 +34,7 @@ mod 'puppetlabs-mysql', '13.3.0'
 mod 'puppetlabs-stdlib', '5.2.0'
 mod 'puppetlabs-transition', '0.1.3'
 mod 'treydock-globus', '9.0.0'
+mod 'saz-limits', '3.0.4'
 
 mod 'computecanada-jupyterhub',
     :git => 'https://github.com/ComputeCanada/puppet-jupyterhub.git',

--- a/site/profile/manifests/slurm.pp
+++ b/site/profile/manifests/slurm.pp
@@ -643,8 +643,48 @@ class profile::slurm::node {
     source_pp => 'puppet:///modules/profile/slurm/slurmd.pp',
   }
 
-  limits::limits{ 'default/memlock':
-    user => 'user',
+
+  # Implementation of user limits as recommended in
+  # https://cloud.google.com/architecture/best-practices-for-using-mpi-on-compute-engine
+  # + some common values found on Compute Canada clusters
+  limits::limits{'default/core':
+    user => '*',
+    soft => '0',
+    hard => 'unlimited'
+  }
+
+  limits::limits{'default/nproc':
+    user => '*',
+    soft => '4096',
+  }
+
+  limits::limits{'default/nproc':
+    user => 'root',
+    soft => 'unlimited',
+  }
+
+  limits::limits{'default/memlock':
+    user => '*',
+    both => 'unlimited',
+  }
+
+  limits::limits{'default/stack':
+    user => '*',
+    both => 'unlimited',
+  }
+
+  limits::limits{'default/nofile':
+    user => '*',
+    both => '1048576',
+  }
+
+  limits::limits{'default/cpu':
+    user => '*',
+    both => 'unlimited',
+  }
+
+  limits::limits{'default/rtprio':
+    user => '*',
     both => 'unlimited',
   }
 

--- a/site/profile/manifests/slurm.pp
+++ b/site/profile/manifests/slurm.pp
@@ -643,6 +643,11 @@ class profile::slurm::node {
     source_pp => 'puppet:///modules/profile/slurm/slurmd.pp',
   }
 
+  limits::limits{ 'default/memlock':
+    user => 'user',
+    both => 'unlimited',
+  }
+
   file { '/localscratch':
     ensure  => 'directory',
     seltype => 'tmp_t'


### PR DESCRIPTION
Based on recommendation from Google Cloud:
https://cloud.google.com/architecture/best-practices-for-using-mpi-on-compute-engine