### PR TITLE
Alertmanager

### DIFF
--- a/data/common.yaml
+++ b/data/common.yaml
@@ -97,6 +97,10 @@ mysql::server::override_options:
       innodb_log_file_size: 64M
       innodb_lock_wait_timeout: 900
 
+lookup_options:
+  prometheus::alerts:
+    merge: 'deep'
+
 prometheus::alerts:
   groups:
     - name: 'recorder.rules'
@@ -203,6 +207,8 @@ prometheus::server::scrape_configs:
 
 prometheus::storage_retention: '48h'
 prometheus::storage_retention_size: '5GB'
+
+prometheus::alertmanager::version: '0.26.0'
 
 profile::squid::server::port: 3128
 profile::squid::server::cache_size: 4096

--- a/data/common.yaml
+++ b/data/common.yaml
@@ -210,6 +210,11 @@ prometheus::storage_retention_size: '5GB'
 
 prometheus::alertmanager::version: '0.26.0'
 
+prometheus::alertmanagers_config:
+  - static_configs:
+    - targets:
+      - "%{hiera('terraform.tag_ip.mgmt.0')}:9093"
+
 profile::squid::server::port: 3128
 profile::squid::server::cache_size: 4096
 profile::squid::server::cvmfs_acl_regex:

--- a/data/site.yaml
+++ b/data/site.yaml
@@ -29,6 +29,7 @@ magic_castle::site::tags:
   mgmt:
     - mysql::server
     - prometheus::server
+    - prometheus::alertmanager
     - profile::metrics::slurm_exporter
     - profile::rsyslog::server
     - profile::squid::server


### PR DESCRIPTION
close #297 

It's not a lot of changes because Alertmanager is already supported by Puppet-Prometheus and is configurable from the hieradata. I made 2 changes:

1. Set a compatible Alertmanager version by default.
 2. Merge the prometheus::alerts to allow adding alerts from the hieradata without overwriting the predefined ones.

Example of hieradata:
```
---
magic_castle::site::tags:
  alertmanager:
    - prometheus::alertmanager

prometheus::service_enable: false

prometheus::alerts:
  groups:
    - name: 'alerts_test'
      rules:
      - alert: HighLoadAlert
        expr: node_load1 > 0.8
        for: 10s
        labels:
          severity: critical
        annotations:
          summary: "High load detected on {{ $labels.instance }}"
          description: "Node load is above 0.8 ({{ $value }}) for more than 10 sec."

prometheus::alertmanagers_config:
  - static_configs:
      - targets:
          - 'localhost:9093'

prometheus::alertmanager::route:
  group_by:
    - 'alertname'
    - 'cluster'
    - 'service'
  group_wait: '5s'
  group_interval: '5m'
  repeat_interval: '3h'
  receiver: 'logging'

prometheus::alertmanager::receivers:
  - name: 'logging'
    webhook_configs:
      - url: 'http://localhost:5001'
```

This add a new tag to `magic_castle::site::tags` and should be apply to the corresponding node in `main.tf`.
@cmd-ntrf What do you think of this solution?