### PR TITLE
Allow to use puppet forge's rsyslog module

### DIFF
--- a/Puppetfile
+++ b/Puppetfile
@@ -34,6 +34,7 @@ mod 'puppetlabs-mysql', '13.3.0'
 mod 'puppetlabs-stdlib', '5.2.0'
 mod 'puppetlabs-transition', '0.1.3'
 mod 'treydock-globus', '9.0.0'
+mod 'puppet-rsyslog', '7.1.0'
 
 mod 'computecanada-jupyterhub',
     :git => 'https://github.com/ComputeCanada/puppet-jupyterhub.git',

--- a/README.md
+++ b/README.md
@@ -1308,13 +1308,20 @@ only type of users in Magic Castle allowed to be sudoers.
 | `users`  | Dictionary of users to be created locally | Hash[profile::users::local_user] |
 
 A `profile::users::local_user` is defined as a dictionary with the following keys:
-| Variable          | Description                                     | Type            | Optional ? |
-| ----------------- | :-----------------------------------------------| :-------------- | ---------  |
-| `groups`          | List of groups the user has to be part of       | Array[String]   | No         |
-| `public_keys`     | List of ssh authorized keys for the user        | Array[String]   | No         |
-| `sudoer`          | If enable, the user can sudo without password   | Boolean         | Yes        |
-| `selinux_user`    | SELinux context for the user                    | String          | Yes        |
-| `mls_range`       | MLS Range for the user                          | String          | Yes        |
+| Variable          | Description                                     | Type            | Optional ? (default) |
+| ----------------- | :-----------------------------------------------| :-------------- | -------------------  |
+| `groups`          | List of groups the user has to be part of       | Array[String]   | No                   |
+| `public_keys`     | List of ssh authorized keys for the user        | Array[String]   | No                   |
+| `sudoer`          | If enable, the user can sudo without password   | Boolean         | Yes (false)          |
+| `selinux_user`    | SELinux context for the user                    | String          | Yes (unconfined_u)   |
+| `mls_range`       | MLS Range for the user                          | String          | Yes (s0-s0:c0.c1023) |
+| `manage_home`     | Whether we manage the home folder               | Boolean         | Yes (true)           |
+| `purge_ssh_keys`  | Whether we purge ssh keys                       | Boolean         | Yes (true)           |
+| `shell`           | Default shell of the user                       | String          | Yes (/bin/bash)      |
+| `uid`             | UID of the user                                 | Integer         | Yes (undef)          |
+| `gid`             | GID of the user                                 | Integer         | Yes (undef)          |
+| `group`           | Primary group name of the user                  | String          | Yes (username)       |
+| `home`            | Home directory of the user                      | String          | Yes (/username)      |
 
 
 <details>

--- a/site/profile/manifests/ceph.pp
+++ b/site/profile/manifests/ceph.pp
@@ -85,14 +85,8 @@ define profile::ceph::client::share (
     owner   => 'root',
     group   => 'root',
   }
-  if length($tuple) > 2 {
-    $type = $tuple[2]
-  }
-  else {
-    $type = directory
-  }
   file { "/mnt/${name}":
-    ensure => $type,
+    ensure => directory,
   }
 
   $mon_host_string = join($mon_host, ',')
@@ -107,8 +101,15 @@ define profile::ceph::client::share (
   $mount_binds.each |$tuple| {
     $src = $tuple[0]
     $dst = $tuple[1]
+    if length($tuple) > 2 {
+      $mount_type = $tuple[2]
+    }
+    else {
+      $mount_type = directory
+    }
+
     file { "/${dst}":
-      ensure  => directory,
+      ensure  => $mount_type,
     }
     mount { "/${dst}":
       ensure  => 'mounted',

--- a/site/profile/manifests/ceph.pp
+++ b/site/profile/manifests/ceph.pp
@@ -25,7 +25,7 @@ class profile::ceph::client (
     content => $ceph_conf,
   }
 
-  ensure_resources(profile::ceph::client::share, $shares, { 'mon_host' => $mon_host, 'mount_binds' => [], 'binds_fcontext_equivalence' => '' })
+  ensure_resources(profile::ceph::client::share, $shares, { 'mon_host' => $mon_host, 'mount_binds' => [] })
 }
 
 class profile::ceph::client::install {
@@ -65,7 +65,7 @@ define profile::ceph::client::share (
   String $access_key,
   String $export_path,
   Array[Tuple[String, String]] $mount_binds,
-  String $binds_fcontext_equivalence,
+  String $binds_fcontext_equivalence = undef,
 ) {
   $client_fullkey = @("EOT")
     [client.${name}]
@@ -116,14 +116,12 @@ define profile::ceph::client::share (
       ],
     }
 
-    if ($binds_fcontext_equivalence != '' and $binds_fcontext_equivalence != "/${dst}") {
+    if ($binds_fcontext_equivalence and $binds_fcontext_equivalence != "/${dst}") {
       selinux::fcontext::equivalence { "/${dst}":
         ensure  => 'present',
         target  => $binds_fcontext_equivalence,
         require => Mount["/${dst}"],
-        notify  => Selinux::Exec_restorecon["/${dst}"],
       }
-      selinux::exec_restorecon { "/${dst}": }
     }
   }
 }

--- a/site/profile/manifests/ceph.pp
+++ b/site/profile/manifests/ceph.pp
@@ -1,62 +1,30 @@
-class profile::ceph::client (
-  String $share_name,
-  String $access_key,
-  String $export_path,
-  Array[String] $mon_host,
-  Array[String] $mount_binds = [],
-  String $mount_name = 'cephfs01',
-  String $binds_fcontext_equivalence = '/home',
-) {
-  class { 'profile::ceph::client::config':
-    share_name  => $share_name,
-    access_key  => $access_key,
-    export_path => $export_path,
-    mon_host    => $mon_host,
+type CephFS = Struct[
+  {
+    'access_key' => String,
+    'export_path' => String,
+    'mount_binds' => Optional[Array[Tuple[String, String]]],
+    'binds_fcontext_equivalence' => Optional[String],
   }
+]
 
-  file { "/mnt/${mount_name}":
-    ensure => directory,
-  }
+class profile::ceph::client (
+  Array[String] $mon_host,
+  Hash[String, CephFS] $shares,
+) {
+  require profile::ceph::client::install
 
   $mon_host_string = join($mon_host, ',')
-  mount { "/mnt/${mount_name}":
-    ensure  => 'mounted',
-    fstype  => 'ceph',
-    device  => "${mon_host_string}:${export_path}",
-    options => "name=${share_name},secretfile=/etc/ceph/client.keyonly.${share_name}",
-    require => Class['profile::ceph::client::config'],
+  $ceph_conf = @("EOT")
+    [client]
+    client quota = true
+    mon host = ${mon_host_string}
+    | EOT
+
+  file { '/etc/ceph/ceph.conf':
+    content => $ceph_conf,
   }
 
-  $mount_binds.each |$mount| {
-    file { "/mnt/${mount_name}/${mount}":
-      ensure  => directory,
-      require => Class['profile::ceph::client::config'],
-    }
-    file { "/${mount}":
-      ensure  => directory,
-      require => Class['profile::ceph::client::config'],
-    }
-    mount { "/${mount}":
-      ensure  => 'mounted',
-      fstype  => 'none',
-      options => 'rw,bind',
-      device  => "/mnt/${mount_name}/${mount}",
-      require => [
-        File["/mnt/${mount_name}/${mount}"],
-        File["/${mount}"],
-      ],
-    }
-
-    if ($binds_fcontext_equivalence != '' and "/${mount}" != $binds_fcontext_equivalence) {
-      selinux::fcontext::equivalence { "/${mount}":
-        ensure  => 'present',
-        target  => $binds_fcontext_equivalence,
-        require => Mount["/${mount}"],
-        notify  => Selinux::Exec_restorecon["/${mount}"],
-      }
-      selinux::exec_restorecon { "/${mount}": }
-    }
-  }
+  ensure_resources(profile::ceph::client::share, $shares, { 'mount_binds' => [], 'binds_fcontext_equivalence' => '/home' })
 }
 
 class profile::ceph::client::install {
@@ -90,41 +58,69 @@ class profile::ceph::client::install {
   }
 }
 
-class profile::ceph::client::config (
-  String $share_name,
+define profile::ceph::client::share (
   String $access_key,
   String $export_path,
-  Array[String] $mon_host,
+  Array[Tuple[String, String]] $mount_binds,
+  String $binds_fcontext_equivalence,
 ) {
-  require profile::ceph::client::install
-
   $client_fullkey = @("EOT")
-    [client.${share_name}]
+    [client.${name}]
     key = ${access_key}
     | EOT
 
-  file { "/etc/ceph/client.fullkey.${share_name}":
+  file { "/etc/ceph/client.fullkey.${name}":
     content => $client_fullkey,
     mode    => '0600',
     owner   => 'root',
     group   => 'root',
   }
 
-  file { "/etc/ceph/client.keyonly.${share_name}":
+  file { "/etc/ceph/client.keyonly.${name}":
     content => Sensitive($access_key),
     mode    => '0600',
     owner   => 'root',
     group   => 'root',
   }
 
-  $mon_host_string = join($mon_host, ',')
-  $ceph_conf = @("EOT")
-    [client]
-    client quota = true
-    mon host = ${mon_host_string}
-    | EOT
+  file { "/mnt/${name}":
+    ensure => directory,
+  }
 
-  file { '/etc/ceph/ceph.conf':
-    content => $ceph_conf,
+  $mon_host_string = join($mon_host, ',')
+  mount { "/mnt/${name}":
+    ensure  => 'mounted',
+    fstype  => 'ceph',
+    device  => "${mon_host_string}:${export_path}",
+    options => "name=${name},secretfile=/etc/ceph/client.keyonly.${name}",
+    require => File['/etc/ceph/ceph.conf'],
+  }
+
+  $mount_binds.each |$tuple| {
+    $src = $tuple[0]
+    $dst = $tuple[1]
+    file { "/${dst}":
+      ensure  => directory,
+    }
+    mount { "/${dst}":
+      ensure  => 'mounted',
+      fstype  => 'none',
+      options => 'rw,bind',
+      device  => "/mnt/${name}/${src}",
+      require => [
+        File["/${dst}"],
+        Mount["/mnt/${name}"]
+      ],
+    }
+
+    if ($binds_fcontext_equivalence != '' and $binds_fcontext_equivalence != "/${dst}") {
+      selinux::fcontext::equivalence { "/${dst}":
+        ensure  => 'present',
+        target  => $binds_fcontext_equivalence,
+        require => Mount["/${dst}"],
+        notify  => Selinux::Exec_restorecon["/${dst}"],
+      }
+      selinux::exec_restorecon { "/${dst}": }
+    }
   }
 }

--- a/site/profile/manifests/ceph.pp
+++ b/site/profile/manifests/ceph.pp
@@ -1,5 +1,6 @@
 type CephFS = Struct[
   {
+    'share_name' => String,
     'access_key' => String,
     'export_path' => String,
     'mount_binds' => Optional[Array[Tuple[String, String]]],
@@ -59,6 +60,7 @@ class profile::ceph::client::install {
 }
 
 define profile::ceph::client::share (
+  String $share_name,
   Array[String] $mon_host,
   String $access_key,
   String $export_path,
@@ -93,7 +95,7 @@ define profile::ceph::client::share (
     ensure  => 'mounted',
     fstype  => 'ceph',
     device  => "${mon_host_string}:${export_path}",
-    options => "name=${name},secretfile=/etc/ceph/client.keyonly.${name}",
+    options => "name=${share_name},secretfile=/etc/ceph/client.keyonly.${name}",
     require => File['/etc/ceph/ceph.conf'],
   }
 

--- a/site/profile/manifests/ceph.pp
+++ b/site/profile/manifests/ceph.pp
@@ -25,7 +25,7 @@ class profile::ceph::client (
     content => $ceph_conf,
   }
 
-  ensure_resources(profile::ceph::client::share, $shares, { 'mon_host' => $mon_host, 'mount_binds' => [], 'binds_fcontext_equivalence' => '/home' })
+  ensure_resources(profile::ceph::client::share, $shares, { 'mon_host' => $mon_host, 'mount_binds' => [], 'binds_fcontext_equivalence' => '' })
 }
 
 class profile::ceph::client::install {

--- a/site/profile/manifests/ceph.pp
+++ b/site/profile/manifests/ceph.pp
@@ -65,7 +65,7 @@ define profile::ceph::client::share (
   String $access_key,
   String $export_path,
   Array[Tuple[String, String]] $mount_binds,
-  String $binds_fcontext_equivalence = undef,
+  Optional[String] $binds_fcontext_equivalence = undef,
 ) {
   $client_fullkey = @("EOT")
     [client.${name}]

--- a/site/profile/manifests/ceph.pp
+++ b/site/profile/manifests/ceph.pp
@@ -3,7 +3,7 @@ type CephFS = Struct[
     'share_name' => String,
     'access_key' => String,
     'export_path' => String,
-    'mount_binds' => Optional[Array[Tuple[String, String]]],
+    'mount_binds' => Optional[Array[Variant[Tuple[String, String], Tuple[String,String,String]]]],
     'binds_fcontext_equivalence' => Optional[String],
   }
 ]
@@ -64,7 +64,7 @@ define profile::ceph::client::share (
   Array[String] $mon_host,
   String $access_key,
   String $export_path,
-  Array[Tuple[String, String]] $mount_binds,
+  Array[Variant[Tuple[String, String], Tuple[String,String,String]]] $mount_binds,
   Optional[String] $binds_fcontext_equivalence = undef,
 ) {
   $client_fullkey = @("EOT")
@@ -85,9 +85,14 @@ define profile::ceph::client::share (
     owner   => 'root',
     group   => 'root',
   }
-
+  if length($tuple) > 2 {
+    $type = $tuple[2]
+  }
+  else {
+    $type = directory
+  }
   file { "/mnt/${name}":
-    ensure => directory,
+    ensure => $type,
   }
 
   $mon_host_string = join($mon_host, ',')

--- a/site/profile/manifests/ceph.pp
+++ b/site/profile/manifests/ceph.pp
@@ -24,7 +24,7 @@ class profile::ceph::client (
     content => $ceph_conf,
   }
 
-  ensure_resources(profile::ceph::client::share, $shares, { 'mount_binds' => [], 'binds_fcontext_equivalence' => '/home' })
+  ensure_resources(profile::ceph::client::share, $shares, { 'mon_host' => $mon_host, 'mount_binds' => [], 'binds_fcontext_equivalence' => '/home' })
 }
 
 class profile::ceph::client::install {
@@ -59,6 +59,7 @@ class profile::ceph::client::install {
 }
 
 define profile::ceph::client::share (
+  Array[String] $mon_host,
   String $access_key,
   String $export_path,
   Array[Tuple[String, String]] $mount_binds,

--- a/site/profile/manifests/rsyslog.pp
+++ b/site/profile/manifests/rsyslog.pp
@@ -1,11 +1,4 @@
 class profile::rsyslog::base {
-  package { 'rsyslog':
-    ensure => 'installed',
-  }
-  service { 'rsyslog':
-    ensure => running,
-    enable => true,
-  }
 }
 
 class profile::rsyslog::client {

--- a/site/profile/manifests/users.pp
+++ b/site/profile/manifests/users.pp
@@ -146,7 +146,7 @@ define profile::users::local_user (
     ensure         => present,
     forcelocal     => true,
     uid            => $uid,
-    gid 	         => $gid,
+    gidi           => $gid,
     groups         => $groups,
     home           => $home,
     purge_ssh_keys => $purge_ssh_keys,

--- a/site/profile/manifests/users.pp
+++ b/site/profile/manifests/users.pp
@@ -156,7 +156,7 @@ define profile::users::local_user (
   }
 
   if $manage_home {
-    selinux::exec_restorecon { "${home}":
+    selinux::exec_restorecon { $home:
       subscribe=> User[$name]
     }
   }

--- a/site/profile/manifests/users.pp
+++ b/site/profile/manifests/users.pp
@@ -130,7 +130,7 @@ define profile::users::local_user (
   String $mls_range = 's0-s0:c0.c1023',
   Boolean $manage_home = true,
   Boolean $purge_ssh_keys = true,
-  Optional[String] $shell = "/bin/bash",
+  Optional[String] $shell = '/bin/bash',
   Optional[Integer] $uid = undef,
   Optional[Integer] $gid = undef,
   Optional[String] $group = $name,

--- a/site/profile/manifests/users.pp
+++ b/site/profile/manifests/users.pp
@@ -134,7 +134,7 @@ define profile::users::local_user (
   Optional[Integer] $uid = undef,
   Optional[Integer] $gid = undef,
   Optional[String] $group = $name,
-  String $home = "/$name",
+  String $home = "/${name}",
 ) {
   group { $group:
     ensure     => present,
@@ -156,7 +156,7 @@ define profile::users::local_user (
   }
 
   if $manage_home {
-    selinux::exec_restorecon { "$home":
+    selinux::exec_restorecon { "${home}":
       subscribe=> User[$name]
     }
   }

--- a/site/profile/manifests/users.pp
+++ b/site/profile/manifests/users.pp
@@ -128,19 +128,38 @@ define profile::users::local_user (
   Boolean $sudoer = false,
   String $selinux_user = 'unconfined_u',
   String $mls_range = 's0-s0:c0.c1023',
+  Boolean $manage_home = true,
+  Boolean $purge_ssh_keys = true,
+  Optional[String] $shell = "/bin/bash",
+  Optional[Integer] $uid = undef,
+  Optional[Integer] $gid = undef,
+  Optional[String] $group = $name,
+  String $home = "/$name",
 ) {
+  group { $group:
+    ensure     => present,
+    gid        => $gid,
+    forcelocal => true,
+  }
   # Configure local account and ssh keys
   user { $name:
     ensure         => present,
     forcelocal     => true,
+    uid            => $uid,
+    gid 	         => $gid,
     groups         => $groups,
-    home           => "/${name}",
-    purge_ssh_keys => true,
-    managehome     => true,
-    notify         => Selinux::Exec_restorecon["/${name}"],
+    home           => $home,
+    purge_ssh_keys => $purge_ssh_keys,
+    managehome     => $manage_home,
+    shell          => $shell,
+    require        => Group[$group],
   }
 
-  selinux::exec_restorecon { "/${name}": }
+  if $manage_home {
+    selinux::exec_restorecon { "$home":
+      subscribe=> User[$name]
+    }
+  }
 
   $public_keys.each | Integer $index, String $sshkey | {
     $split = split($sshkey, ' ')

--- a/site/profile/manifests/users.pp
+++ b/site/profile/manifests/users.pp
@@ -146,7 +146,7 @@ define profile::users::local_user (
     ensure         => present,
     forcelocal     => true,
     uid            => $uid,
-    gidi           => $gid,
+    gid            => $gid,
     groups         => $groups,
     home           => $home,
     purge_ssh_keys => $purge_ssh_keys,


### PR DESCRIPTION
To avoid this PR from causing issue, one must define these yaml parameters: 
```
rsyslog::purge_config_files: false
rsyslog::override_default_config: false
``` 

I am not sure where best to set those