### PR TITLE
Disable mig if previously enabled

### DIFF
--- a/site/profile/manifests/gpu.pp
+++ b/site/profile/manifests/gpu.pp
@@ -99,8 +99,25 @@ class profile::gpu::install::passthrough (
   }
 
   $mig_profile = lookup("terraform.instances.${facts['networking']['hostname']}.specs.mig")
-  if $mig_profile {
+  if $mig_profile and !$mig_profile.empty {
     include profile::gpu::install::mig
+  }
+  else {
+    exec {'disable_mig':
+      command     => 'nvidia-mig-parted apply',
+      onlyif      => ['nvidia-mig-parted assert ; test $? -eq 1'],
+      environment => [
+        'MIG_PARTED_CONFIG_FILE=/etc/nvidia-mig-manager/config.yaml',
+        'MIG_PARTED_HOOKS_FILE=/etc/nvidia-mig-manager/puppet-hooks.yaml',
+        'MIG_PARTED_SELECTED_CONFIG=all-disabled',
+        'MIG_PARTED_SKIP_RESET=false',
+      ],
+      path        => ['/usr/bin'],
+      notify      => [
+        Service['nvidia-persistenced'],
+        Service['nvidia-dcgm'],
+      ]
+    }
   }
 
   package { $packages:


### PR DESCRIPTION
Disable MIG on GPU if Terraform value is "null" of "{}".

The `onlyif` line (`'nvidia-mig-parted assert ; test $? -eq 1'` is probably not perfect. But it checks if `nvidia-mig-parted` is present and if the configuration is correctly apply at the same time. I'm open to better suggestion. 