### PR TITLE
Allow to disable Slurm's spank plugin to manage tmpfs mounts

### DIFF
--- a/site/profile/manifests/slurm.pp
+++ b/site/profile/manifests/slurm.pp
@@ -559,8 +559,9 @@ export TFE_VAR_POOL=${tfe_var_pool}
 }
 
 # Slurm node class. This is where slurmd is ran.
-class profile::slurm::node 
+class profile::slurm::node (
   Boolean $enable_tmpfs_mounts = true,
+)
 {
   contain profile::slurm::base
 

--- a/site/profile/manifests/slurm.pp
+++ b/site/profile/manifests/slurm.pp
@@ -194,6 +194,7 @@ class profile::slurm::base (
         'suspend_time'          => $suspend_time,
         'memlimit'              => $os_reserved_memory,
         'partitions'            => $partitions,
+	'enable_tmpfs_mounts'   => $enable_tmpfs_mounts,
       }),
     group   => 'slurm',
     owner   => 'slurm',
@@ -558,48 +559,53 @@ export TFE_VAR_POOL=${tfe_var_pool}
 }
 
 # Slurm node class. This is where slurmd is ran.
-class profile::slurm::node {
+class profile::slurm::node 
+  Boolean $enable_tmpfs_mounts = true,
+{
   contain profile::slurm::base
 
   $slurm_version = lookup('profile::slurm::base::slurm_version')
-  if versioncmp($slurm_version, '22.05') >= 0 {
-    $cc_tmpfs_mounts_url = "https://download.copr.fedorainfracloud.org/results/cmdntrf/spank-cc-tmpfs_mounts-${slurm_version}/"
-  } else {
-    $cc_tmpfs_mounts_url = 'https://download.copr.fedorainfracloud.org/results/cmdntrf/spank-cc-tmpfs_mounts/'
+  if $enable_tmpfs_mounts {
+    if versioncmp($slurm_version, '22.05') >= 0 {
+      $cc_tmpfs_mounts_url = "https://download.copr.fedorainfracloud.org/results/cmdntrf/spank-cc-tmpfs_mounts-${slurm_version}/"
+    } else {
+      $cc_tmpfs_mounts_url = 'https://download.copr.fedorainfracloud.org/results/cmdntrf/spank-cc-tmpfs_mounts/'
+    }
+ 
+    yumrepo { 'spank-cc-tmpfs_mounts-copr-repo':
+      enabled             => true,
+      descr               => 'Copr repo for spank-cc-tmpfs_mounts owned by cmdntrf',
+      baseurl             => "${cc_tmpfs_mounts_url}/epel-\$releasever-\$basearch/",
+      skip_if_unavailable => true,
+      gpgcheck            => 1,
+      gpgkey              => "${cc_tmpfs_mounts_url}/pubkey.gpg",
+      repo_gpgcheck       => 0,
+    }
+    package { 'spank-cc-tmpfs_mounts':
+      ensure  => 'installed',
+      require => [
+        Package['slurm-slurmd'],
+        Yumrepo['spank-cc-tmpfs_mounts-copr-repo'],
+      ]
+    }
+    file { '/etc/slurm/plugstack.conf':
+      ensure  => 'present',
+      owner   => 'slurm',
+      group   => 'slurm',
+      notify  => Service['slurmd'],
+      content => @(EOT/L),
+        required /opt/software/slurm/lib64/slurm/cc-tmpfs_mounts.so \
+        bindself=/tmp bindself=/dev/shm target=/localscratch bind=/var/tmp/
+        |EOT
+    }
   }
 
-  yumrepo { 'spank-cc-tmpfs_mounts-copr-repo':
-    enabled             => true,
-    descr               => 'Copr repo for spank-cc-tmpfs_mounts owned by cmdntrf',
-    baseurl             => "${cc_tmpfs_mounts_url}/epel-\$releasever-\$basearch/",
-    skip_if_unavailable => true,
-    gpgcheck            => 1,
-    gpgkey              => "${cc_tmpfs_mounts_url}/pubkey.gpg",
-    repo_gpgcheck       => 0,
-  }
 
   package { ['slurm-slurmd', 'slurm-pam_slurm']:
     ensure  => 'installed',
     require => Package['slurm']
   }
 
-  package { 'spank-cc-tmpfs_mounts':
-    ensure  => 'installed',
-    require => [
-      Package['slurm-slurmd'],
-      Yumrepo['spank-cc-tmpfs_mounts-copr-repo'],
-    ]
-  }
-
-  file { '/etc/slurm/plugstack.conf':
-    ensure  => 'present',
-    owner   => 'slurm',
-    group   => 'slurm',
-    content => @(EOT/L),
-      required /opt/software/slurm/lib64/slurm/cc-tmpfs_mounts.so \
-      bindself=/tmp bindself=/dev/shm target=/localscratch bind=/var/tmp/
-      |EOT
-  }
 
   pam { 'Add pam_slurm_adopt':
     ensure   => present,
@@ -674,7 +680,6 @@ class profile::slurm::node {
     enable    => true,
     subscribe => [
       File['/etc/slurm/cgroup.conf'],
-      File['/etc/slurm/plugstack.conf'],
       File['/etc/slurm/slurm.conf'],
       File['/etc/slurm/slurm-addendum.conf'],
       File['/etc/slurm/nodes.conf'],

--- a/site/profile/templates/slurm/slurm.conf.epp
+++ b/site/profile/templates/slurm/slurm.conf.epp
@@ -59,7 +59,9 @@ PrologFlags=alloc,contain
 <% } -%>
 # Prolog=/etc/slurm/prolog
 Epilog=/etc/slurm/epilog
+<% if $enable_tmpfs_mounts { -%>
 PlugStackConfig=/etc/slurm/plugstack.conf
+<% } -%>
 MpiDefault=pmi2
 ProctrackType=proctrack/cgroup
 <% if versioncmp($slurm_version, '21.08') >= 0 { -%>


### PR DESCRIPTION
This fixes https://github.com/ComputeCanada/puppet-magic_castle/issues/336