### PR TITLE
if authenticationmethods is specified for a local user, configure an sshd exception

### DIFF
--- a/README.md
+++ b/README.md
@@ -1315,7 +1315,7 @@ A `profile::users::local_user` is defined as a dictionary with the following key
 | `sudoer`          | If enable, the user can sudo without password   | Boolean         | Yes        |
 | `selinux_user`    | SELinux context for the user                    | String          | Yes        |
 | `mls_range`       | MLS Range for the user                          | String          | Yes        |
-
+| `authenticationmethods` | Specifies AuthenticationMethods value for this user in sshd_config | String          | Yes        |
 
 <details>
 <summary>default values</summary>
@@ -1326,6 +1326,7 @@ profile::users::local::users:
     public_keys: "%{alias('terraform.data.public_keys')}"
     groups: ['adm', 'wheel', 'systemd-journal']
     sudoer: true
+    authenticationmethods: 'publickey'
 ```
 
 If `profile::users::local::users` is present in more than one YAML file in the hierarchy,
@@ -1346,5 +1347,6 @@ profile::users::local::users:
     # sudoer: false
     # selinux_user: 'unconfined_u'
     # mls_range: ''s0-s0:c0.c1023'
+    # authenticationmethods: 'publickey,password publickey,keyboard-interactive'
 ```
 </details>

--- a/data/common.yaml
+++ b/data/common.yaml
@@ -267,6 +267,7 @@ profile::users::local::users:
     public_keys: "%{alias('terraform.data.public_keys')}"
     groups: ['adm', 'wheel', 'systemd-journal']
     sudoer: true
+    authenticationmethods: 'publickey'
 
 
 profile::freeipa::base::domain_name: "%{alias('terraform.data.domain_name')}"

--- a/site/profile/manifests/users.pp
+++ b/site/profile/manifests/users.pp
@@ -128,6 +128,7 @@ define profile::users::local_user (
   Boolean $sudoer = false,
   String $selinux_user = 'unconfined_u',
   String $mls_range = 's0-s0:c0.c1023',
+  String $authenticationmethods = '',
 ) {
   # Configure local account and ssh keys
   user { $name:
@@ -170,5 +171,14 @@ define profile::users::local_user (
     path    => '/etc/sudoers.d/90-puppet-users',
     line    => "${name} ALL=(ALL) NOPASSWD:ALL",
     require => File['/etc/sudoers.d/90-puppet-users'],
+  }
+
+  if $authenticationmethods != '' {
+    sshd_config { "${name} authenticationmethods":
+      ensure    => present,
+      condition => "User ${name}",
+      key       => 'AuthenticationMethods',
+      value     => $authenticationmethods
+    }
   }
 }


### PR DESCRIPTION
and does so automatically for the user used by Terraform cloud. 

This addresses comment 
https://github.com/ComputeCanada/puppet-magic_castle/issues/307#issuecomment-1922318385
