### PR TITLE
Elasticsearch support for Rsyslog

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ The `profile::` sections list the available classes, their role and their parame
 - [`profile::rsyslog::base`](#profilersyslogbase)
 - [`profile::rsyslog::client`](#profilersyslogclient)
 - [`profile::rsyslog::server`](#profilersyslogserver)
+- [`profile::rsyslog::elasticsearch`](#profilersyslogelasticsearch)
 - [`profile::slurm::base`](#profileslurmbase)
 - [`profile::slurm::accounting`](#profileslurmaccounting)
 - [`profile::slurm::controller`](#profileslurmcontroller)
@@ -866,6 +867,30 @@ from all rsyslog client in the cluster.
 
 When `profile::rsyslog::server` is included, these classes are included too:
 - [profile::consul](#profileconsul)
+- [profile::rsyslog::base](#profilersyslogbase)
+
+## `profile::rsyslog::elasticsearch`
+
+This class install and configures rsyslog service to forward logs
+to Elasticsearch/Opensearch. 
+When used with `profile::rsyslog::server`, logs from all clients are included.
+
+### parameters
+
+| Variable                | Description              | Type    | Optional ? |
+| :---------------------- | :----------------------- | :------ | ---------  |
+| `server_url`            | URL to Elasticsearch server | String  | No         |
+| `server_port`           | Port to Elasticsearch server | String  | No        |
+| `index`                 | Elasticsearch index      | String  | No        |
+| `username`              | Username for HTTP authentification      | String  | Yes        |
+| `password`              | Password for HTTP authentification      | String  | Yes        |
+| `program_names`         | Include logs from those programs only   | Array[String]  | Yes        |
+| `tags`         | Tags to includes in the request   | Hash[String, String]  | Yes        |
+
+
+### dependencies
+
+When `profile::rsyslog::elasticsearch` is included, these classes are included too:
 - [profile::rsyslog::base](#profilersyslogbase)
 
 ## `profile::slurm::base`

--- a/site/profile/manifests/rsyslog.pp
+++ b/site/profile/manifests/rsyslog.pp
@@ -70,3 +70,32 @@ class profile::rsyslog::server {
     notify => Service['rsyslog'],
   }
 }
+
+class profile::rsyslog::elasticsearch
+(
+  String $server_url,
+  String $server_port,
+  String $index,
+  String $username = '',
+  String $password = '',
+  Array[String] $program_names = [],
+  Hash[String, String] $tags = {}
+)
+{
+  package { 'rsyslog-elasticsearch':
+    ensure => 'installed',
+  }
+
+  file { '/etc/rsyslog.d/80-elasticsearch.conf':
+    notify  => Service['rsyslog'],
+    content => epp('profile/rsyslog/elasticsearch.conf', {
+        'server_url'    => $server_url,
+        'server_port'   => $server_port,
+        'index'         => $index,
+        'username'      => $username,
+        'password'      => $password,
+        'program_names' => $program_names,
+        'tags'          => $tags,
+    }),
+  }
+}

--- a/site/profile/manifests/rsyslog.pp
+++ b/site/profile/manifests/rsyslog.pp
@@ -82,6 +82,8 @@ class profile::rsyslog::elasticsearch
   Hash[String, String] $tags = {}
 )
 {
+  include profile::rsyslog::base
+
   package { 'rsyslog-elasticsearch':
     ensure => 'installed',
   }

--- a/site/profile/templates/rsyslog/elasticsearch.conf.epp
+++ b/site/profile/templates/rsyslog/elasticsearch.conf.epp
@@ -1,0 +1,46 @@
+module(load="omelasticsearch")
+
+# Define the Elasticsearch template
+template(
+  name="es-template"
+  type="list"
+  option.json="on"
+) {
+  constant(value="{")
+  constant(value="\"@timestamp\":\"")
+  property(name="timereported" dateFormat="rfc3339")
+  constant(value="\",\"host\":\"")
+  property(name="hostname")
+  constant(value="\",\"program\":\"")
+  property(name="programname")
+  constant(value="\",\"severity\":\"")
+  property(name="syslogseverity-text")
+  constant(value="\",\"facility\":\"")
+  property(name="syslogfacility-text")
+  constant(value="\",\"syslogtag\":\"")
+  property(name="syslogtag")
+  constant(value="\",\"message\":\"")
+  property(name="msg" format="json")
+<% $tags.each |$key, $value| { -%>
+  constant(value="\",\"<%= $key %>\":\"<%= $value %>")
+<% } -%>
+  constant(value="\"}")
+}
+
+<% if !$program_names.empty { -%>
+if (
+    <%= $program_names.map |$name| { "\$programname == \'$name\'" }.join(" or ") %>
+) then {
+<% } -%>
+ action(
+  type="omelasticsearch"
+  template="es-template"
+  server="<%= $server_url %>"
+  serverport="<%= $server_port %>"
+  searchIndex="<%= $index %>"
+  <%= if $username != '' { "uid=\"$username\"" } %>
+  <%= if $password != '' { "pwd=\"$password\"" } %>
+ )
+<% if !$program_names.empty { -%>
+}
+<% } -%>


### PR DESCRIPTION
Add a profile to send log to elastic search from rsyslog. 
Also, adding this profile with `profile::rsyslog::server` will include all node on the cluster.