### PR TITLE
Support for Vector.dev

### DIFF
--- a/README.md
+++ b/README.md
@@ -931,7 +931,7 @@ Refer to the [documentation](https://vector.dev/docs/) for configuration.
 
 | Variable                | Description              | Type    | Optional ? |
 | :---------------------- | :----------------------- | :------ | ---------  |
-| `config`                | Content of the configuration file | String  | Yes  |
+| `config`                | Content of the yaml configuration file | String  | Yes  |
 | `access_var_log`        | Set `/var/log` group to `vector`  | Boolean | Yes  |
 
 ## `profile::slurm::base`

--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ The `profile::` sections list the available classes, their role and their parame
 - [`profile::rsyslog::base`](#profilersyslogbase)
 - [`profile::rsyslog::client`](#profilersyslogclient)
 - [`profile::rsyslog::server`](#profilersyslogserver)
+- [`profile::vector`](#profilervector)
 - [`profile::slurm::base`](#profileslurmbase)
 - [`profile::slurm::accounting`](#profileslurmaccounting)
 - [`profile::slurm::controller`](#profileslurmcontroller)
@@ -920,6 +921,18 @@ from all rsyslog client in the cluster.
 When `profile::rsyslog::server` is included, these classes are included too:
 - [profile::consul](#profileconsul)
 - [profile::rsyslog::base](#profilersyslogbase)
+
+## `profile::vector`
+
+This class install and configures vector.dev service to manager logs.
+Refer to the [documentation](https://vector.dev/docs/) for configuration.
+
+### parameters
+
+| Variable                | Description              | Type    | Optional ? |
+| :---------------------- | :----------------------- | :------ | ---------  |
+| `config`                | Content of the configuration file | String  | Yes  |
+| `access_var_log`        | Set `/var/log` group to `vector`  | Boolean | Yes  |
 
 ## `profile::slurm::base`
 

--- a/site/profile/files/vector/default_config.yaml
+++ b/site/profile/files/vector/default_config.yaml
@@ -1,0 +1,11 @@
+sources:
+  in:
+    type: "stdin"
+
+sinks:
+  out:
+    inputs:
+      - "in"
+    type: "console"
+    encoding:
+      codec: "text"

--- a/site/profile/manifests/vector.pp
+++ b/site/profile/manifests/vector.pp
@@ -1,0 +1,47 @@
+class profile::vector
+(
+  String $config = file('puppet:///modules/profile/vector/default_config.yaml'),
+  Boolean $access_var_log = false,
+)
+{
+  yumrepo { 'vector':
+    ensure        => present,
+    enabled       => true,
+    baseurl       => "https://yum.vector.dev/stable/vector-0/${::facts['architecture']}/",
+    gpgcheck      => 1,
+    gpgkey        => [
+      'https://keys.datadoghq.com/DATADOG_RPM_KEY_CURRENT.public',
+      'https://keys.datadoghq.com/DATADOG_RPM_KEY_B01082D3.public',
+      'https://keys.datadoghq.com/DATADOG_RPM_KEY_FD4BF915.public',
+    ],
+    repo_gpgcheck => 1,
+  }
+
+  package { 'vector':
+    ensure  => 'installed',
+    require => [Yumrepo['vector']],
+  }
+
+  service { 'vector':
+    ensure  => running,
+    enable  => true,
+    require => [Package['vector']],
+  }
+
+  file { '/etc/vector/vector.yaml':
+    notify  => Service['vector'],
+    content => $config,
+    require => [Package['vector']],
+  }
+
+  if $access_var_log {
+    file { '/var/log':
+      ensure  => directory,
+      group   => 'vector',
+      recurse => true,
+      notify  => Service['vector'],
+      require => [Package['vector']],
+    }
+  }
+}
+


### PR DESCRIPTION
Add support for vector.dev.

All configuration is done from the hieradata as a string.
There's a second arg to set `/var/log` group as `vector`. This allow vector to read file under /var/log. @cmd-ntrf What do you think about this? Otherwise, should we add vector to the `root` group?