### PR TITLE
use sshd_config provider instead of file_line for UseDNS and HostbasedAuthentication

### DIFF
--- a/site/profile/manifests/ssh.pp
+++ b/site/profile/manifests/ssh.pp
@@ -105,17 +105,15 @@ class profile::ssh::hostbased_auth::server (
     content => $shosts,
   }
 
-  file_line { 'HostbasedAuthentication':
+  sshd_config { 'HostbasedAuthentication':
     ensure => present,
-    path   => '/etc/ssh/sshd_config',
-    line   => 'HostbasedAuthentication yes',
+    value  => 'yes',
     notify => Service['sshd'],
   }
 
-  file_line { 'UseDNS':
+  sshd_config { 'UseDNS':
     ensure => present,
-    path   => '/etc/ssh/sshd_config',
-    line   => 'UseDNS yes',
+    value  => 'yes',
     notify => Service['sshd'],
   }
 


### PR DESCRIPTION
Otherwise, and since https://github.com/ComputeCanada/puppet-magic_castle/pull/340 was merged, we get things like
```
Jun 14 18:00:28 node1.int.archimedes.c3.ca puppet-agent[8395]: (/Stage[main]/Profile::Ssh::Base/Service[sshd]) Jun 14 18:00:28 node1.int.archimedes.c3.ca sshd[8657]: /etc/ssh/sshd_config line 137: Directive 'UseDNS' is not allowed within a Match block
``` 

because the `UseDNS` and `HostbasedAuthentication` appear at the end of the `sshd_config` file, instead of having the `Match` blocks at the end of the file. 