### PR TITLE
Set Nvidia driver stream to proprietary version

### DIFF
--- a/data/common.yaml
+++ b/data/common.yaml
@@ -294,7 +294,6 @@ profile::jupyterhub::hub::register_url: "https://mokey.%{lookup('terraform.data.
 profile::jupyterhub::hub::reset_pw_url: "https://mokey.%{lookup('terraform.data.domain_name')}/auth/forgotpw"
 
 profile::gpu::install::passthrough::packages:
-  - kmod-nvidia-latest-dkms # require to be first package, otherwise kmod-nivida is installed
   - nvidia-driver-cuda-libs
   - nvidia-driver
   - nvidia-driver-devel

--- a/site/profile/manifests/gpu.pp
+++ b/site/profile/manifests/gpu.pp
@@ -82,7 +82,7 @@ class profile::gpu::install (
 
 class profile::gpu::install::passthrough (
   Array[String] $packages,
-  String $nvidia_driver_stream = '550-dkms'
+  String $nvidia_driver_stream = '555-dkms'
 ) {
   $os = "rhel${::facts['os']['release']['major']}"
   $arch = $::facts['os']['architecture']


### PR DESCRIPTION
Latest NVIDIA driver (>= v560) switch to the open source driver version and it has some conflict with MC. This fix set the driver to v550 with the proprietary version.

There's still an issue with the driver >= v560 where the persistenced user is not created, but it could be fix in another PR.