### PR TITLE
Fix nvidia-driver stream ressource creation at every refresh

### DIFF
--- a/site/profile/manifests/gpu.pp
+++ b/site/profile/manifests/gpu.pp
@@ -94,8 +94,8 @@ class profile::gpu::install::passthrough (
   }
 
   package { 'nvidia-stream':
-    ensure      => present,
-    name        => "nvidia-driver:${nvidia_driver_stream}",
+    ensure      => $nvidia_driver_stream,
+    name        => 'nvidia-driver',
     provider    => dnfmodule,
     enable_only => true,
     require     => [


### PR DESCRIPTION
The previous syntax was not working properly and the resource was refresh at every Puppet iteration. I found this syntax from puppet [dnfmodule code](https://github.com/puppetlabs/puppet/blob/main/lib/puppet/provider/package/dnfmodule.rb#L8).