### PR TITLE
Fix quota exec command

### DIFF
--- a/site/profile/manifests/volumes.pp
+++ b/site/profile/manifests/volumes.pp
@@ -166,11 +166,23 @@ define profile::volumes::volume (
   }
 
   if $filesystem == 'xfs' and $quota {
+    file { '/etc/xfs_quota':
+      ensure  => 'directory',
+    }
+
+    # Save the xfs quota setting to avoid applying at every iteration
+    file { "/etc/xfs_quota/${volume_tag}-${volume_name}":
+      ensure  => 'file',
+      content => $quota,
+      require => File['/etc/xfs_quota']
+    }
+
     exec { "apply-quota-${name}":
-      command => "xfs_quota -x -c 'limit bsoft=${quota} bhard=${quota} -d' /mnt/${volume_tag}/${volume_name} && echo ${quota} > /tmp/quota-${name}",
-      require => Mount["/mnt/${volume_tag}/${volume_name}"],
-      path    => ['/bin', '/usr/bin', '/sbin', '/usr/sbin'],
-      unless  => "grep -q '${quota}' /tmp/quota-${name}",
+      command     => "xfs_quota -x -c 'limit bsoft=${quota} bhard=${quota} -d' /mnt/${volume_tag}/${volume_name}",
+      require     => Mount["/mnt/${volume_tag}/${volume_name}"],
+      path        => ['/bin', '/usr/bin', '/sbin', '/usr/sbin'],
+      refreshonly => true,
+      subscribe   => [File["/etc/xfs_quota/${volume_tag}-${volume_name}"]],
     }
   }
 }

--- a/site/profile/manifests/volumes.pp
+++ b/site/profile/manifests/volumes.pp
@@ -167,10 +167,10 @@ define profile::volumes::volume (
 
   if $filesystem == 'xfs' and $quota {
     exec { "apply-quota-${name}":
-      command     => "xfs_quota -x -c 'limit bsoft=${quota} bhard=${quota} -d' /mnt/${name}",
-      require     => Mount["/mnt/${volume_tag}/${volume_name}"],
-      path        => ['/bin', '/usr/bin', '/sbin', '/usr/sbin'],
-      refreshonly => true,
+      command => "xfs_quota -x -c 'limit bsoft=${quota} bhard=${quota} -d' /mnt/${volume_tag}/${volume_name} && echo ${quota} > /tmp/quota-${name}",
+      require => Mount["/mnt/${volume_tag}/${volume_name}"],
+      path    => ['/bin', '/usr/bin', '/sbin', '/usr/sbin'],
+      unless  => "grep -q '${quota}' /tmp/quota-${name}",
     }
   }
 }

--- a/site/profile/manifests/volumes.pp
+++ b/site/profile/manifests/volumes.pp
@@ -174,7 +174,7 @@ define profile::volumes::volume (
     # Save the xfs quota setting to avoid applying at every iteration
     file { "/etc/xfs_quota/${volume_tag}-${volume_name}":
       ensure  => 'file',
-      content => $quota,
+      content => "#FILE TRACKED BY PUPPET DO NOT EDIT MANUALLY\n${quota}",
       require => File['/etc/xfs_quota']
     }
 

--- a/site/profile/manifests/volumes.pp
+++ b/site/profile/manifests/volumes.pp
@@ -17,6 +17,11 @@
 class profile::volumes (
   Hash[String, Hash[String, Hash]] $devices,
 ) {
+
+  file { '/etc/xfs_quota':
+    ensure  => 'directory',
+  }
+
   if $devices =~ Hash[String, Hash[String, Hash]] {
     package { 'lvm2':
       ensure => installed,
@@ -166,10 +171,6 @@ define profile::volumes::volume (
   }
 
   if $filesystem == 'xfs' and $quota {
-    file { '/etc/xfs_quota':
-      ensure  => 'directory',
-    }
-
     # Save the xfs quota setting to avoid applying at every iteration
     file { "/etc/xfs_quota/${volume_tag}-${volume_name}":
       ensure  => 'file',


### PR DESCRIPTION
There were two issues with the previous exec command:
1. The path was wrong
2. The exec was never executed because of the `refreshonly=true`

@cmd-ntrf To avoid executing the command at every execution, I create a file with the quota state. I haven't found a better way to verify the current quota but I'm open to a better alternative. 

