### PR TITLE
Use dynamic user for nvidia-persistenced service

### DIFF
--- a/site/profile/manifests/gpu.pp
+++ b/site/profile/manifests/gpu.pp
@@ -122,13 +122,6 @@ class profile::gpu::install::passthrough (
   # Used by slurm-job-exporter to export GPU metrics
   -> package { 'datacenter-gpu-manager': }
 
-  -> file { '/run/nvidia-persistenced':
-    ensure => directory,
-    owner  => 'root',
-    group  => 'root',
-    mode   => '0755',
-  }
-
   -> augeas { 'nvidia-persistenced.service':
     context => '/files/lib/systemd/system/nvidia-persistenced.service/Service',
     changes => [
@@ -137,11 +130,6 @@ class profile::gpu::install::passthrough (
       'set RuntimeDirectory/value nvidia-persistenced',
       'rm ExecStart/arguments',
     ],
-  }
-
-  file { '/usr/lib/tmpfiles.d/nvidia-persistenced.conf':
-    content => 'd /run/nvidia-persistenced 0755 nvidia-persistenced nvidia-persistenced -',
-    mode    => '0644',
   }
 }
 

--- a/site/profile/manifests/gpu.pp
+++ b/site/profile/manifests/gpu.pp
@@ -124,16 +124,17 @@ class profile::gpu::install::passthrough (
 
   -> file { '/run/nvidia-persistenced':
     ensure => directory,
-    owner  => 'nvidia-persistenced',
-    group  => 'nvidia-persistenced',
+    owner  => 'root',
+    group  => 'root',
     mode   => '0755',
   }
 
   -> augeas { 'nvidia-persistenced.service':
     context => '/files/lib/systemd/system/nvidia-persistenced.service/Service',
     changes => [
-      'set User/value nvidia-persistenced',
-      'set Group/value nvidia-persistenced',
+      'set DynamicUser/value yes',
+      'set StateDirectory/value nvidia-persistenced',
+      'set RuntimeDirectory/value nvidia-persistenced',
       'rm ExecStart/arguments',
     ],
   }

--- a/site/profile/manifests/gpu.pp
+++ b/site/profile/manifests/gpu.pp
@@ -82,7 +82,7 @@ class profile::gpu::install (
 
 class profile::gpu::install::passthrough (
   Array[String] $packages,
-  String $nvidia_driver_stream = '555-dkms'
+  String $nvidia_driver_stream = '560-dkms'
 ) {
   $os = "rhel${::facts['os']['release']['major']}"
   $arch = $::facts['os']['architecture']


### PR DESCRIPTION
With the latest nvidia driver (>=560) the `nvidia-persistenced` user is not created anymore. This user is only required for the `nvidia-persistenced.service`. This PR remove the user need by using a [dynamic user](https://0pointer.net/blog/dynamic-users-with-systemd.html) in the service.

