### PR TITLE
Fix quota condition

### DIFF
--- a/site/profile/manifests/volumes.pp
+++ b/site/profile/manifests/volumes.pp
@@ -97,7 +97,7 @@ define profile::volumes::volume (
   if $filesystem == 'xfs' {
     $options = 'defaults,usrquota'
   } else {
-    $options = ''
+    $options = 'defaults'
   }
 
   lvm::logical_volume { $name:

--- a/site/profile/manifests/volumes.pp
+++ b/site/profile/manifests/volumes.pp
@@ -42,7 +42,7 @@ class profile::volumes (
           enable_resize => pick($values['enable_resize'], false),
           filesystem    => pick($values['filesystem'], 'xfs'),
           require       => File["/mnt/${volume_tag}"],
-          quota         => pick($values['quota'], nil),
+          quota         => pick_default($values['quota'], undef),
         }
       }
     }
@@ -94,7 +94,7 @@ define profile::volumes::volume (
     followsymlinks   => true,
   }
 
-  if $filesystem == 'xfs' and $quota {
+  if $filesystem == 'xfs' {
     $options = 'defaults,usrquota'
   } else {
     $options = ''
@@ -170,7 +170,7 @@ define profile::volumes::volume (
     }
   }
 
-  if $filesystem == 'xfs' and $quota {
+  if $filesystem == 'xfs' and $quota != undef {
     # Save the xfs quota setting to avoid applying at every iteration
     file { "/etc/xfs_quota/${volume_tag}-${volume_name}":
       ensure  => 'file',


### PR DESCRIPTION
The main issue with the last fix was that the "defaults" option was not set for XFS. `usrquota` is always set even if there is no quota. There is no issue related to that and it was like this for month in MC.