### PR TITLE
Add nvidia-driver-cuda to the list of passthrough packages

### DIFF
--- a/data/common.yaml
+++ b/data/common.yaml
@@ -302,3 +302,4 @@ profile::gpu::install::passthrough::packages:
   - nvidia-modprobe
   - nvidia-xconfig
   - nvidia-persistenced
+  - nvidia-driver-cuda


### PR DESCRIPTION
Since 560, this is the package that installs nvidia-smi which is required to configure the GPU in Slurm gres file.