### PR TITLE
Fix quota condition 

### DIFF
--- a/site/profile/manifests/volumes.pp
+++ b/site/profile/manifests/volumes.pp
@@ -42,7 +42,7 @@ class profile::volumes (
           enable_resize => pick($values['enable_resize'], false),
           filesystem    => pick($values['filesystem'], 'xfs'),
           require       => File["/mnt/${volume_tag}"],
-          quota         => pick_default($values['quota'], undef),
+          quota         => pick_default($values['quota'], ''),
         }
       }
     }
@@ -61,7 +61,7 @@ define profile::volumes::volume (
   String $seltype,
   Boolean $enable_resize,
   Enum['xfs', 'ext3', 'ext4'] $filesystem,
-  Optional[String] $quota = undef,
+  String $quota = '',
 ) {
   $regex = Regexp(regsubst($glob, /[?*]/, { '?' => '.', '*' => '.*' }))
 
@@ -170,7 +170,7 @@ define profile::volumes::volume (
     }
   }
 
-  if $filesystem == 'xfs' and $quota != undef {
+  if $filesystem == 'xfs' and $quota != '' {
     # Save the xfs quota setting to avoid applying at every iteration
     file { "/etc/xfs_quota/${volume_tag}-${volume_name}":
       ensure  => 'file',


### PR DESCRIPTION
There was an issue with the quota condition when it was not set. `pick_default($values['quota'], undef)` return an empty string instead of `undef`. For this reason I changed the default value to an empty string and modify the condition accordingly. 