### PR TITLE
Revert "Update key to install vector"

### DIFF
--- a/site/profile/manifests/vector.pp
+++ b/site/profile/manifests/vector.pp
@@ -9,7 +9,9 @@ class profile::vector
     baseurl       => "https://yum.vector.dev/stable/vector-0/${::facts['architecture']}/",
     gpgcheck      => 1,
     gpgkey        => [
-      'https://yum.vector.dev/DATADOG_RPM_KEY_CURRENT.public',
+      'https://keys.datadoghq.com/DATADOG_RPM_KEY_CURRENT.public',
+      'https://keys.datadoghq.com/DATADOG_RPM_KEY_B01082D3.public',
+      'https://keys.datadoghq.com/DATADOG_RPM_KEY_FD4BF915.public',
     ],
     repo_gpgcheck => 1,
   }


### PR DESCRIPTION
This reverts commit 553506a3b8f4a7f6f85f4bfbe63a84e37a518d49. I don't really know what happened, but the YUM repo is using the old key from Datadog again.