### PR TITLE
Fix url for jupyterhub ui options

### DIFF
--- a/data/common.yaml
+++ b/data/common.yaml
@@ -56,21 +56,21 @@ jupyterhub::jupyterhub_config_hash:
     ui_args:
       notebook:
         name: Jupyter Notebook
-        args: ['--SingleUserNotebookApp.default_url=/tree']
+        url: '/tree'
       lab:
         name: JupyterLab
       terminal:
         name: Terminal
-        args: ['--SingleUserNotebookApp.default_url=/terminals/1']
+        url: '/terminals/1'
       rstudio:
         name: RStudio
-        args: ['--SingleUserNotebookApp.default_url=/rstudio']
+        url: '/rstudio'
       code-server:
         name: VS Code
-        args: ['--SingleUserNotebookApp.default_url=/code-server']
+        url: '/code-server'
       desktop:
         name: Desktop
-        args: ['--SingleUserNotebookApp.default_url=/Desktop']
+        url: '/Desktop'
 
   SbatchForm:
     ui:


### PR DESCRIPTION
To specify which ui to start with, slurmformspawner now accepts `url` and set JUPYTERHUB_DEFAULT_URL environment variable instead.