### PR TITLE
Remove munge's epel yumrepo requirement

### DIFF
--- a/site/profile/manifests/slurm.pp
+++ b/site/profile/manifests/slurm.pp
@@ -58,7 +58,6 @@ class profile::slurm::base (
 
   package { 'munge':
     ensure  => 'installed',
-    require => Yumrepo['epel']
   }
 
   file { '/var/log/slurm':


### PR DESCRIPTION
munge is provided by appstream since RHEL8