### PR TITLE
add option to define mkfs_options for volumes

### DIFF
--- a/site/profile/manifests/volumes.pp
+++ b/site/profile/manifests/volumes.pp
@@ -43,7 +43,7 @@ class profile::volumes (
           filesystem    => pick($values['filesystem'], 'xfs'),
           require       => File["/mnt/${volume_tag}"],
           quota         => pick_default($values['quota'], ''),
-          mkfs_options  => pick($values['mkfs_options'], ''),
+          mkfs_options  => pick_default($values['mkfs_options'], ''),
         }
       }
     }

--- a/site/profile/manifests/volumes.pp
+++ b/site/profile/manifests/volumes.pp
@@ -43,6 +43,7 @@ class profile::volumes (
           filesystem    => pick($values['filesystem'], 'xfs'),
           require       => File["/mnt/${volume_tag}"],
           quota         => pick_default($values['quota'], ''),
+          mkfs_options  => pick($values['mkfs_options'], ''),
         }
       }
     }
@@ -62,6 +63,7 @@ define profile::volumes::volume (
   Boolean $enable_resize,
   Enum['xfs', 'ext3', 'ext4'] $filesystem,
   String $quota = '',
+  String $mkfs_options = '',
 ) {
   $regex = Regexp(regsubst($glob, /[?*]/, { '?' => '.', '*' => '.*' }))
 
@@ -104,6 +106,7 @@ define profile::volumes::volume (
     ensure            => present,
     volume_group      => "${name}_vg",
     fs_type           => $filesystem,
+    mkfs_options      => $mkfs_options,
     mountpath         => "/mnt/${volume_tag}/${volume_name}",
     mountpath_require => true,
     options           => $options,


### PR DESCRIPTION
This fixes https://github.com/ComputeCanada/magic_castle/issues/325

Once this is merged, one can define for example
```
project  = { 
  size = 500,
  quota = "50g", 
  mkfs_options = "-K"  
}

``` 
in the terraform specification, and the time required to create the filesystem on SSD goes from about 30 minutes: 
```
Jan 06 21:24:07 mgmt1.int.nsc7003.calculquebec.cloud puppet-agent[1118]: (/Stage[main]/Profile::Volumes/Profile::Volumes::Volume[nfs-project]/Lvm::Logical_volume[nfs-project]/Logical_volume[nfs-project]/ensure) created
Jan 06 21:52:35 mgmt1.int.nsc7003.calculquebec.cloud puppet-agent[1118]: (/Stage[main]/Profile::Volumes/Profile::Volumes::Volume[nfs-project]/Lvm::Logical_volume[nfs-project]/Filesystem[/dev/nfs-project_vg/nfs-project]/ensure) created
``` 

to a second: 
```
Jan 13 17:01:16 mgmt1.int.test-mc-infra-cours-juno.calculquebec.cloud puppet-agent[1102]: (/Stage[main]/Profile::Volumes/Profile::Volumes::Volume[nfs-project]/Lvm::Logical_volume[nfs-project]/Logical_volume[nfs-project]/ensure) created
Jan 13 17:01:17 mgmt1.int.test-mc-infra-cours-juno.calculquebec.cloud puppet-agent[1102]: (/Stage[main]/Profile::Volumes/Profile::Volumes::Volume[nfs-project]/Lvm::Logical_volume[nfs-project]/Filesystem[/dev/nfs-project_vg/nfs-project]/ensure) created
``` 
