### PR TITLE
added annotations using `rake test` results

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -5,7 +5,7 @@ require 'puppet-lint-param-docs/tasks'
 require 'puppet-syntax/tasks/puppet-syntax'
 
 PuppetLint.configuration.send("disable_80chars")
-PuppetLint.configuration.log_format = "%{path}:%{line}:%{check}:%{KIND}:%{message}"
+PuppetLint.configuration.log_format = "::%{kind} file=%{path},line=%{line},col=%{column},title=%{check}::%{message}"
 PuppetLint.configuration.fail_on_warnings = true
 PuppetLint.configuration.send('disable_autoloader_layout')
 


### PR DESCRIPTION
Formatting puppet-lint output to use Github workflow commands `::error` and `::warning`, creating annotations in the **Files changed** tab of a pull_request