### PR TITLE
Move require Tcp_conn_validator['consul'] to profile::consul

### DIFF
--- a/site/profile/manifests/rsyslog.pp
+++ b/site/profile/manifests/rsyslog.pp
@@ -38,8 +38,7 @@ class profile::rsyslog::server {
   include profile::rsyslog::base
 
   @consul::service { 'rsyslog':
-    port    => 514,
-    require => Tcp_conn_validator['consul'],
+    port => 514,
   }
 
   file { '/etc/rsyslog.d/98-remotelogs.conf':

--- a/site/profile/manifests/slurm.pp
+++ b/site/profile/manifests/slurm.pp
@@ -342,8 +342,7 @@ class profile::slurm::accounting(
   }
 
   @consul::service { 'slurmdbd':
-    port    => $dbd_port,
-    require => Tcp_conn_validator['consul'],
+    port => $dbd_port,
   }
 
   wait_for { 'slurmdbd_started':
@@ -528,8 +527,7 @@ export TFE_VAR_POOL=${tfe_var_pool}
   }
 
   @consul::service { 'slurmctld':
-    port    => 6817,
-    require => Tcp_conn_validator['consul'],
+    port => 6817,
   }
 
   package { 'slurm-slurmctld':

--- a/site/profile/manifests/software_stack.pp
+++ b/site/profile/manifests/software_stack.pp
@@ -77,8 +77,7 @@ class profile::software_stack (
   }
 
   @consul::service { 'software_stack':
-    ensure  => $ensure_stack,
-    require => Tcp_conn_validator['consul'],
-    meta    => $software_stack_meta,
+    ensure => $ensure_stack,
+    meta   => $software_stack_meta,
   }
 }

--- a/site/profile/manifests/squid.pp
+++ b/site/profile/manifests/squid.pp
@@ -67,7 +67,6 @@ class profile::squid::server (
   }
 
   @consul::service { 'squid':
-    port    => $port,
-    require => Tcp_conn_validator['consul'],
+    port => $port,
   }
 }


### PR DESCRIPTION
Also fix an issue with Tcp_con_validator trying to use 'consul' as the host and try to connect to port 80 instead of using the provided host and port. Since Magic Castle has a wildcard dns record, Tcp_conn_validator resolved the 'consul' resource name as consul.int.cluster_name.domain_name.tld. The resource name is always used first in Tcp_conn_validator.
https://github.com/voxpupuli/puppet-healthcheck/blob/db422e0a93beb72a9de0b579c8e51d27ec15f7d3/lib/puppet_x/puppet-community/tcp_validator.rb#L17