### PR TITLE
Fix issues that prevents mgmt and nfs tags to be greater than 1.

### DIFF
--- a/README.md
+++ b/README.md
@@ -606,6 +606,7 @@ This class configures files and services of a FreeIPA server.
 | `admin_password` | Password of the FreeIPA admin account       | String         |
 | `ds_password`    | Password of the directory server            | String         |
 | `hbac_services`  | Name of services to control with HBAC rules | Array[String]  |
+| `enable_mokey`   | Enable the [mokey service](#profilefreeipamokey) | Booelan   |
 
 <details>
 <summary>default values</summary>
@@ -615,6 +616,7 @@ profile::freeipa::server::id_start: 60001
 profile::freeipa::server::admin_password: ENC[PKCS7,...]
 profile::freeipa::server::ds_password: ENC[PKCS7,...]
 profile::freeipa::server::hbac_services: ["sshd", "jupyterhub-login"]
+profile::freeipa::server::enable_mokey: true
 ```
 
 </details>

--- a/README.md
+++ b/README.md
@@ -111,7 +111,6 @@ magic_castle::site::tags:
     - profile::freeipa::mokey
     - profile::slurm::accounting
     - profile::accounts
-    - profile::users::ldap
   node:
     - profile::cvmfs::client
     - profile::gpu

--- a/data/site.yaml
+++ b/data/site.yaml
@@ -48,7 +48,7 @@ magic_castle::site::tags:
     - profile::ssh::hostbased_auth::client
     - profile::ssh::hostbased_auth::server
     - profile::metrics::slurm_job_exporter
-    - profile::nfs::client
+    - profile::nfs
     - profile::software_stack
   nfs:
     - profile::nfs

--- a/data/site.yaml
+++ b/data/site.yaml
@@ -38,7 +38,6 @@ magic_castle::site::tags:
     - profile::rsyslog::server
     - profile::squid::server
     - profile::slurm::controller
-    - profile::freeipa::mokey
     - profile::slurm::accounting
     - profile::accounts
     - profile::nfs

--- a/data/site.yaml
+++ b/data/site.yaml
@@ -51,7 +51,7 @@ magic_castle::site::tags:
     - profile::nfs::client
     - profile::software_stack
   nfs:
-    - profile::nfs::server
+    - profile::nfs
     - profile::cvmfs::alien_cache
   proxy:
     - profile::jupyterhub::hub

--- a/data/site.yaml
+++ b/data/site.yaml
@@ -42,7 +42,6 @@ magic_castle::site::tags:
     - profile::slurm::accounting
     - profile::accounts
     - profile::nfs
-    - profile::users::ldap
   node:
     - profile::gpu
     - profile::jupyterhub::node

--- a/site/profile/files/accounts/account_functions.sh
+++ b/site/profile/files/accounts/account_functions.sh
@@ -138,9 +138,13 @@ mkproject() {
             fi
         fi
         # We create the associated account in slurm
-        /opt/software/slurm/bin/sacctmgr add account $GROUP -i &> /dev/null
+        local sacctmgr_output=$(/opt/software/slurm/bin/sacctmgr add account $GROUP -i 2>&1)
         if [ $? -eq 0 ]; then
             echo "INFO::${FUNCNAME} ${GROUP}: SlurmDB account created"
+        else
+            echo "ERROR::${FUNCNAME} ${GROUP}: could not create SlurmDB account:"
+            echo "${sacctmgr_output}" | sed 's/^/\t/'
+            return 1
         fi
         rmdir /var/lock/mkproject.$GROUP.lock
     fi
@@ -216,9 +220,13 @@ modproject() {
                 fi
             done
         fi
-        /opt/software/slurm/bin/sacctmgr add user ${USERNAMES} Account=${GROUP} -i &> /dev/null
+        local sacctmgr_output=$(/opt/software/slurm/bin/sacctmgr add user ${USERNAMES} Account=${GROUP} -i 2>&1)
         if [ $? -eq 0 ]; then
             echo "INFO::${FUNCNAME} ${GROUP}: ${USERNAMES} added to ${GROUP} in SlurmDB"
+        else
+            echo "ERROR::${FUNCNAME} ${GROUP}: could not add ${USERNAMES} added to ${GROUP}"
+            echo "${sacctmgr_output}" | sed 's/^/\t/'
+            return 1
         fi
     else
         # If group has been modified but no uid were found in the log, it means

--- a/site/profile/files/accounts/mkhome.service
+++ b/site/profile/files/accounts/mkhome.service
@@ -4,8 +4,8 @@ BindsTo=ipa.service
 
 [Service]
 Type=simple
-StandardOutput=syslog
-StandardError=syslog
+StandardOutput=journal
+StandardError=journal
 SyslogIdentifier=mkhome
 ExecStart=/sbin/mkhome.sh
 

--- a/site/profile/files/accounts/mkproject.service
+++ b/site/profile/files/accounts/mkproject.service
@@ -4,8 +4,8 @@ BindsTo=ipa.service
 
 [Service]
 Type=simple
-StandardOutput=syslog
-StandardError=syslog
+StandardOutput=journal
+StandardError=journal
 SyslogIdentifier=mkproject
 ExecStart=/sbin/mkproject.sh
 

--- a/site/profile/manifests/accounts.pp
+++ b/site/profile/manifests/accounts.pp
@@ -95,7 +95,7 @@ class profile::accounts (
   }
 
   $mkhome_running = $manage_home or $manage_scratch
-  service { 'mkhome':
+  @service { 'mkhome':
     ensure    => $mkhome_running,
     enable    => $mkhome_running,
     subscribe => [
@@ -123,7 +123,7 @@ class profile::accounts (
 
   # mkproject is always running even if /project does not exist
   # because it also handles the creation of Slurm accounts
-  service { 'mkproject':
+  @service { 'mkproject':
     ensure    => running,
     enable    => true,
     subscribe => [

--- a/site/profile/manifests/accounts.pp
+++ b/site/profile/manifests/accounts.pp
@@ -11,13 +11,6 @@ class profile::accounts (
   Boolean $manage_project = true,
   Array[Struct[{ filename => String[1], source => String[1] }]] $skel_archives = [],
 ) {
-  Service <| tag == profile::slurm |> -> Service['mkhome']
-  Service <| tag == profile::slurm |> -> Service['mkproject']
-  Service <| tag == profile::freeipa |> -> Service['mkhome']
-  Service <| tag == profile::freeipa |> -> Service['mkproject']
-  Mount <| |> -> Service['mkhome']
-  Mount <| |> -> Service['mkproject']
-
   package { 'rsync':
     ensure => 'installed',
   }

--- a/site/profile/manifests/freeipa.pp
+++ b/site/profile/manifests/freeipa.pp
@@ -462,6 +462,9 @@ class profile::freeipa::server (
       Exec['reset ds password'],
     ],
   }
+
+  Service <| tag == 'profile::accounts' and title == 'mkhome' |>
+  Service <| tag == 'profile::accounts' and title == 'mkproject' |>
 }
 
 class profile::freeipa::mokey (

--- a/site/profile/manifests/freeipa.pp
+++ b/site/profile/manifests/freeipa.pp
@@ -192,11 +192,16 @@ class profile::freeipa::server (
   String $admin_password,
   String $ds_password,
   Array[String] $hbac_services = ['sshd', 'jupyterhub-login'],
+  Boolean $enable_mokey = true,
 ) {
   include profile::base::etc_hosts
   include profile::freeipa::base
   include profile::sssd::client
   include profile::users::ldap
+
+  if $enable_mokey {
+    include profile::freeipa::mokey
+  }
 
   file { 'kinit_wrapper':
     path   => '/usr/bin/kinit_wrapper',

--- a/site/profile/manifests/freeipa.pp
+++ b/site/profile/manifests/freeipa.pp
@@ -463,8 +463,8 @@ class profile::freeipa::server (
     ],
   }
 
-  Service <| tag == 'profile::accounts' and title == 'mkhome' |>
-  Service <| tag == 'profile::accounts' and title == 'mkproject' |>
+  Service <| tag == profile::freeipa |> -> Service <| tag == 'profile::accounts' and title == 'mkhome' |>
+  Service <| tag == profile::freeipa |> -> Service <| tag == 'profile::accounts' and title == 'mkproject' |>
 }
 
 class profile::freeipa::mokey (

--- a/site/profile/manifests/freeipa.pp
+++ b/site/profile/manifests/freeipa.pp
@@ -196,6 +196,7 @@ class profile::freeipa::server (
   include profile::base::etc_hosts
   include profile::freeipa::base
   include profile::sssd::client
+  include profile::users::ldap
 
   file { 'kinit_wrapper':
     path   => '/usr/bin/kinit_wrapper',

--- a/site/profile/manifests/metrics.pp
+++ b/site/profile/manifests/metrics.pp
@@ -108,7 +108,7 @@ class profile::metrics::apache_exporter {
     port => 9117,
     tags => ['exporter'],
   }
-  realize File['/etc/httpd/conf.d/server-status.conf']
+  File<| title == '/etc/httpd/conf.d/server-status.conf' |>
 }
 
 class profile::metrics::caddy_exporter (Integer $port = 2020) {

--- a/site/profile/manifests/nfs.pp
+++ b/site/profile/manifests/nfs.pp
@@ -28,7 +28,7 @@ class profile::nfs::client (
     $options_nfsv4 = 'proto=tcp,nosuid,nolock,noatime,actimeo=3,nfsvers=4.2,seclabel,x-systemd.automount,x-systemd.mount-timeout=30,_netdev'
     $nfs_export_list.each | String $name | {
       if $self_volumes.any |$tag, $volume_hash| { $name in $volume_hash } {
-        $mount_name = "nfs-${name}"
+        $mount_name = "nfs/${name}"
       } else {
         $mount_name = $name
       }

--- a/site/profile/manifests/nfs.pp
+++ b/site/profile/manifests/nfs.pp
@@ -22,11 +22,17 @@ class profile::nfs::client (
   $instances = lookup('terraform.instances')
   $nfs_server = Hash($instances.map| $key, $values | { [$values['local_ip'], $key] })[$server_ip]
   $nfs_volumes = $instances.dig($nfs_server, 'volumes', 'nfs')
+  $self_volumes = lookup('terraform.self.volumes')
   if $nfs_volumes =~ Hash[String, Hash] {
     $nfs_export_list = keys($nfs_volumes)
     $options_nfsv4 = 'proto=tcp,nosuid,nolock,noatime,actimeo=3,nfsvers=4.2,seclabel,x-systemd.automount,x-systemd.mount-timeout=30,_netdev'
     $nfs_export_list.each | String $name | {
-      nfs::client::mount { "/${name}":
+      if $self_volumes.any |$tag, $volume_hash| { $name in $volume_hash } {
+        $mount_name = "nfs-${name}"
+      } else {
+        $mount_name = $name
+      }
+      nfs::client::mount { "/${mount_name}":
         ensure        => present,
         server        => $server_ip,
         share         => $name,

--- a/site/profile/manifests/nfs.pp
+++ b/site/profile/manifests/nfs.pp
@@ -26,11 +26,13 @@ class profile::nfs::client (
   if $nfs_volumes =~ Hash[String, Hash] {
     $nfs_export_list = keys($nfs_volumes)
     $options_nfsv4 = 'proto=tcp,nosuid,nolock,noatime,actimeo=3,nfsvers=4.2,seclabel,x-systemd.automount,x-systemd.mount-timeout=30,_netdev'
-    $nfs_export_list.each | String $name | {
-      if $self_volumes.any |$tag, $volume_hash| { $name in $volume_hash } {
-        $mount_name = "nfs/${name}"
+    $nfs_export_list.each | String $share_name | {
+      # If the instance has a volume mounted under the same name as the nfs share,
+      # we mount the nfs share under /nfs/${share_name}.
+      if $self_volumes.any |$tag, $volume_hash| { $share_name in $volume_hash } {
+        $mount_name = "nfs/${share_name}"
       } else {
-        $mount_name = $name
+        $mount_name = $share_name
       }
       nfs::client::mount { "/${mount_name}":
         ensure        => present,

--- a/site/profile/manifests/nfs.pp
+++ b/site/profile/manifests/nfs.pp
@@ -99,4 +99,6 @@ class profile::nfs::server (
       }
     }
   }
+  Mount <| |> -> Service <| tag == 'profile::accounts' and title == 'mkhome' |>
+  Mount <| |> -> Service <| tag == 'profile::accounts' and title == 'mkproject' |>
 }

--- a/site/profile/manifests/slurm.pp
+++ b/site/profile/manifests/slurm.pp
@@ -397,9 +397,6 @@ class profile::slurm::accounting(
     create_group => 'slurm',
     postrotate   => '/usr/bin/pkill -x --signal SIGUSR2 slurmdbd',
   }
-
-  Service <| tag == profile::slurm::accounting |> -> Service <| tag == 'profile::accounts' and title == 'mkhome' |>
-  Service <| tag == profile::slurm::accounting |> -> Service <| tag == 'profile::accounts' and title == 'mkproject' |>
 }
 
 # Slurm controller class. This where slurmctld is ran.
@@ -568,9 +565,6 @@ export TFE_VAR_POOL=${tfe_var_pool}
     create_group => 'slurm',
     postrotate   => '/usr/bin/pkill -x --signal SIGUSR2 slurmctld',
   }
-
-  Service <| tag == profile::slurm::controller |> -> Service <| tag == 'profile::accounts' and title == 'mkhome' |>
-  Service <| tag == profile::slurm::controller |> -> Service <| tag == 'profile::accounts' and title == 'mkproject' |>
 }
 
 # Slurm node class. This is where slurmd is ran.

--- a/site/profile/manifests/slurm.pp
+++ b/site/profile/manifests/slurm.pp
@@ -398,6 +398,8 @@ class profile::slurm::accounting(
     postrotate   => '/usr/bin/pkill -x --signal SIGUSR2 slurmdbd',
   }
 
+  Service <| tag == profile::slurm::accounting |> -> Service <| tag == 'profile::accounts' and title == 'mkhome' |>
+  Service <| tag == profile::slurm::accounting |> -> Service <| tag == 'profile::accounts' and title == 'mkproject' |>
 }
 
 # Slurm controller class. This where slurmctld is ran.
@@ -566,6 +568,9 @@ export TFE_VAR_POOL=${tfe_var_pool}
     create_group => 'slurm',
     postrotate   => '/usr/bin/pkill -x --signal SIGUSR2 slurmctld',
   }
+
+  Service <| tag == profile::slurm::controller |> -> Service <| tag == 'profile::accounts' and title == 'mkhome' |>
+  Service <| tag == profile::slurm::controller |> -> Service <| tag == 'profile::accounts' and title == 'mkproject' |>
 }
 
 # Slurm node class. This is where slurmd is ran.

--- a/site/profile/manifests/users.pp
+++ b/site/profile/manifests/users.pp
@@ -2,7 +2,8 @@ class profile::users::ldap (
   Hash $users,
   Array[String] $access_tags,
 ) {
-  Exec <| tag == profile::freeipa |> -> Profile::Users::Ldap_user <| |>
+  Exec <| title == 'ipa-install' |> -> Profile::Users::Ldap_user <| |>
+  Exec <| title == 'hbac_rules' |> ~> Profile::Users::Ldap_user <| |>
   Exec <| tag == profile::accounts |> -> Profile::Users::Ldap_user <| |>
   Service <| tag == profile::freeipa |> -> Profile::Users::Ldap_user <| |>
   Service <| tag == profile::accounts |> -> Profile::Users::Ldap_user <| |>
@@ -87,7 +88,6 @@ define profile::users::ldap_user (
         returns     => [0, 1, 2],
         subscribe   => [
           Exec["ldap_user_${name}"],
-          Exec['hbac_rules'],
         ],
       }
     }

--- a/site/profile/templates/slurm/slurm.conf.epp
+++ b/site/profile/templates/slurm/slurm.conf.epp
@@ -1,8 +1,9 @@
 include /etc/slurm/nodes.conf
 
 <% if ! $slurmctl.empty { -%>
-SlurmctldHost=<%= join($slurmctl, ',') %>
-<% } -%>
+<% $slurmctl.each | $hostname| { -%>
+SlurmctldHost=<%= $hostname %>
+<% }} -%>
 SlurmctldPort=6817
 
 ## Accounting

--- a/site/profile/templates/slurm/slurm.conf.epp
+++ b/site/profile/templates/slurm/slurm.conf.epp
@@ -9,6 +9,9 @@ SlurmctldPort=6817
 ## Accounting
 <% if ! $slurmdb.empty { -%>
 AccountingStorageHost=<%= $slurmdb[0] %>
+<% if length($slurmdb) > 1 { -%>
+AccountingStorageBackupHost=<%= $slurmdb[1] %>
+<% } -%>
 AccountingStorageType=accounting_storage/slurmdbd
 AccountingStorageTRES=gres/gpu,cpu,mem
 AccountingStorageEnforce=associations

--- a/site/profile/templates/slurm/slurm.conf.epp
+++ b/site/profile/templates/slurm/slurm.conf.epp
@@ -7,7 +7,7 @@ SlurmctldPort=6817
 
 ## Accounting
 <% if ! $slurmdb.empty { -%>
-AccountingStorageHost=<%= join($slurmdb, ',') %>
+AccountingStorageHost=<%= $slurmdb[0] %>
 AccountingStorageType=accounting_storage/slurmdbd
 AccountingStorageTRES=gres/gpu,cpu,mem
 AccountingStorageEnforce=associations

--- a/site/profile/templates/slurm/slurm.conf.epp
+++ b/site/profile/templates/slurm/slurm.conf.epp
@@ -67,8 +67,8 @@ SlurmctldLogFile=/var/log/slurm/slurmctld.log
 SlurmdDebug=debug
 SlurmdLogFile=/var/log/slurm/slurmd.log
 
-SlurmctldPidFile=/var/run/slurmctld.pid
-SlurmdPidFile=/var/run/slurmd.pid
+SlurmctldPidFile=/var/run/slurmctld/slurmctld.pid
+SlurmdPidFile=/var/run/slurmd/slurmd.pid
 
 # JOBS AND TASKS/RESOURCES CONTROL
 TmpFS=/localscratch

--- a/site/profile/templates/slurm/slurmdbd.conf.epp
+++ b/site/profile/templates/slurm/slurmdbd.conf.epp
@@ -1,5 +1,6 @@
 AuthType=auth/munge
 LogFile=/var/log/slurm/slurmdbd.log
+PidFile=/var/run/slurmdbd/slurmdbd.pid
 DbdHost=<%= $dbd_host %>
 DbdPort=<%= $dbd_port %>
 SlurmUser=slurm


### PR DESCRIPTION
- Fix slurmctld backup host format in slurm.conf
- Fix slurmdbd backup format in slurm.conf
- Move mokey inclusion from site.yaml to freeipa::server class guarantee uniqueness
- Look for conflicts between NFS share mounts and volume mount, and address conflict by mounting nfs share under /nfs when conflict happens.