### PR TITLE
Add an 'automember_groups' parameter to freeipa::server 

### DIFF
--- a/README.md
+++ b/README.md
@@ -607,6 +607,7 @@ This class configures files and services of a FreeIPA server.
 | `ds_password`    | Password of the directory server            | String         |
 | `hbac_services`  | Name of services to control with HBAC rules | Array[String]  |
 | `enable_mokey`   | Enable the [mokey service](#profilefreeipamokey) | Booelan   |
+| `automember_groups` | Define groups that new users are automatically added to | Array[String] |
 
 <details>
 <summary>default values</summary>
@@ -617,6 +618,7 @@ profile::freeipa::server::admin_password: ENC[PKCS7,...]
 profile::freeipa::server::ds_password: ENC[PKCS7,...]
 profile::freeipa::server::hbac_services: ["sshd", "jupyterhub-login"]
 profile::freeipa::server::enable_mokey: true
+profile::freeipa::server::automember_groups: ['def-sponsor00']
 ```
 
 </details>

--- a/site/profile/templates/freeipa/group_automember_rules.py.epp
+++ b/site/profile/templates/freeipa/group_automember_rules.py.epp
@@ -1,0 +1,11 @@
+#!/bin/bash
+# 1. Create an automember rule for each group
+# 2. Add a condition to the automember rule to add all users to that group
+# 3. Rebuild the automember rules
+api.Command.batch(
+<% $automember_groups.each |$group| { -%>
+  { 'method': 'automember_add', 'params': [[], {'cn': '<%= $group %>', 'type': 'group', 'all': False, 'raw': False}]},
+  { 'method': 'automember_add_condition', 'params': [[], {'cn': '<%= $group %>', 'key': 'uid', 'type': 'group', 'all': False, 'raw': False, 'automemberinclusiveregex': '.*'}]},
+<% } -%>
+  { 'method': 'automember_rebuild', 'params': [[], {'type': 'group'}] },
+)


### PR DESCRIPTION
This configures a FreeIPA automember rule so that new users are automatically added to these groups. 

This fixes #327 

