### PR TITLE
Adds a "groups_hbacrules" parameter to freeipa::server

### DIFF
--- a/README.md
+++ b/README.md
@@ -607,6 +607,7 @@ This class configures files and services of a FreeIPA server.
 | `ds_password`    | Password of the directory server            | String         |
 | `hbac_services`  | Name of services to control with HBAC rules | Array[String]  |
 | `enable_mokey`   | Enable the [mokey service](#profilefreeipamokey) | Booelan   |
+| `groups_hbacrules`   | Add a group to an array of HBAC rules | Optional[Hash[String, Array[String]]] |
 
 <details>
 <summary>default values</summary>
@@ -617,6 +618,7 @@ profile::freeipa::server::admin_password: ENC[PKCS7,...]
 profile::freeipa::server::ds_password: ENC[PKCS7,...]
 profile::freeipa::server::hbac_services: ["sshd", "jupyterhub-login"]
 profile::freeipa::server::enable_mokey: true
+profile::freeipa::server::groups_hbacrules: undef
 ```
 
 </details>

--- a/site/profile/templates/freeipa/hbac_users.py.epp
+++ b/site/profile/templates/freeipa/hbac_users.py.epp
@@ -1,0 +1,8 @@
+#!/bin/bash
+api.Command.batch(
+<% $groups_hbacrules.each |$group, $hbacrules| { -%>
+  <% $hbacrules.each |$rule| { -%>
+    { 'method': 'hbacrule_add_user', 'params': [['<%= $rule %>'], {'group': '<%= $group %>'}] },
+  <% } -%>
+<% } -%>
+)


### PR DESCRIPTION
When defined, the group will be added to a list of hbac rules.

For example: 
```
profile::freeipa::server::groups_hbacrules:
  'def-sponsor00': ['login:sshd', 'login:node']
``` 

This fixes #425 