### PR TITLE
refactor ldap groups as standalone and allow configuring rules for each group

### DIFF
--- a/README.md
+++ b/README.md
@@ -636,7 +636,6 @@ This class installs mokey, configures its files and manage its service.
 | `port`                 | Mokey internal web server port                                 | Integer       |
 | `enable_user_signup`   | Allow users to create an account on the cluster                | Boolean       |
 | `require_verify_admin` | Require a FreeIPA to enable Mokey created account before usage | Boolean       |
-| `access_tags`          | HBAC rule access tags for users created via mokey self-signup  | Array[String] |
 
 <details>
 <summary>default values</summary>
@@ -646,7 +645,6 @@ profile::freeipa::mokey::password: ENC[PKCS7,...]
 profile::freeipa::mokey::port: 12345
 profile::freeipa::mokey::enable_user_signup: true
 profile::freeipa::mokey::require_verify_admin: true
-profile::freeipa::mokey::access_tags: "%{alias('profile::users::ldap::access_tags')}"
 ```
 </details>
 
@@ -1341,7 +1339,6 @@ or to use [Mokey](#profilefreeipamokey).
 | ------------- | :-------------------------------------------------------- | :------------------------------ |
 | `users`       | Dictionary of users to be created in LDAP                 | Hash[profile::users::ldap_user] |
 | `groups`      | Dictionary of users to be created in LDAP                 | Hash[String, profile::users::ldap_group_rules] |
-| `access_tags` | List of `'tag:service'` that LDAP user can connect to     | Array[String]                   |
 
 A `profile::users::ldap_user` is defined as a dictionary with the following keys:
 | Variable          | Description                                               | Type                            | Optional ? |
@@ -1373,7 +1370,6 @@ profile::users::ldap::users:
     groups: ['def-sponsor00']
     manage_password: true
 
-profile::users::ldap::access_tags: ['login:sshd', 'node:sshd', 'proxy:jupyterhub-login']
 profile::users::ldap::groups:
   'def-sponsor00':
     automember: true
@@ -1407,7 +1403,9 @@ profile::users::ldap::users:
 
 Allowing LDAP users to connect to the cluster only via JupyterHub:
 ```yaml
-profile::users::ldap::access_tags: ['proxy:jupyterhub-login']
+profile::users::ldap::groups:
+  'def-sponsor00':
+    hbacrules: ['proxy:jupyterhub-login']
 ```
 
 </details>

--- a/README.md
+++ b/README.md
@@ -1340,6 +1340,7 @@ or to use [Mokey](#profilefreeipamokey).
 | Variable      | Description                                               | Type                            |
 | ------------- | :-------------------------------------------------------- | :------------------------------ |
 | `users`       | Dictionary of users to be created in LDAP                 | Hash[profile::users::ldap_user] |
+| `groups`      | Dictionary of users to be created in LDAP                 | Hash[String, profile::users::ldap_group_rules] |
 | `access_tags` | List of `'tag:service'` that LDAP user can connect to     | Array[String]                   |
 
 A `profile::users::ldap_user` is defined as a dictionary with the following keys:
@@ -1349,6 +1350,12 @@ A `profile::users::ldap_user` is defined as a dictionary with the following keys
 | `public_keys`     | List of ssh authorized keys for the user                  | Array[String]                   | Yes        |
 | `passwd`          | User's password                                           | String                          | Yes        |
 | `manage_password` | If enable, agents verify the password hashes match        | Boolean                         | Yes        |
+
+A `profile::users::ldap_group_rules` is defined as a dictionary with the following keys:
+| Variable          | Description                                               | Type                            | Optional ? |
+| ----------------- | :-------------------------------------------------------- | :------------------------------ | ---------  |
+| `automember`      | Whether users are automatically member of that group      | Boolean                         | Yes        |
+| `hbacrules`       | List of HBAC rules that apply to this group               | Array[String]                   | Yes        |
 
 
 By default, Puppet will manage the LDAP user(s) password and change it in LDAP if its hash no
@@ -1367,6 +1374,10 @@ profile::users::ldap::users:
     manage_password: true
 
 profile::users::ldap::access_tags: ['login:sshd', 'node:sshd', 'proxy:jupyterhub-login']
+profile::users::ldap::groups:
+  'def-sponsor00':
+    automember: true
+    hbacrules: ['login:sshd', 'node:sshd', 'proxy:jupyterhub-login']
 ```
 
 If `profile::users::ldap::users` is present in more than one YAML file in the hierarchy,

--- a/data/common.yaml
+++ b/data/common.yaml
@@ -2,6 +2,8 @@
 lookup_options:
   profile::users::ldap::users:
     merge: 'deep'
+  profile::users::ldap::groups:
+    merge: 'deep'
   profile::users::local::users:
     merge: 'deep'
   jupyterhub::jupyterhub_config_hash:
@@ -297,6 +299,10 @@ profile::users::ldap::users:
     passwd: "%{alias('terraform.data.guest_passwd')}"
     groups: ['def-sponsor00']
     manage_password: true
+profile::users::ldap::groups:
+  'def-sponsor00':
+    automember: true
+    hbacrules: ['login:sshd', 'node:sshd', 'proxy:jupyterhub-login']
 
 profile::users::local::users:
   "%{alias('terraform.data.sudoer_username')}":

--- a/site/profile/files/users/ipa_create_user.py
+++ b/site/profile/files/users/ipa_create_user.py
@@ -115,12 +115,10 @@ def main(users, posix_groups, nonposix_groups, passwd, sshpubkeys):
 
     if posix_groups:
         for group in posix_groups:
-            group_add(group)
             group_add_members(group, users)
 
     if nonposix_groups:
         for group in nonposix_groups:
-            group_add(group, nonposix=True)
             group_add_members(group, users)
 
     if passwd:

--- a/site/profile/manifests/freeipa.pp
+++ b/site/profile/manifests/freeipa.pp
@@ -472,7 +472,6 @@ class profile::freeipa::mokey (
   String $password,
   Boolean $enable_user_signup,
   Boolean $require_verify_admin,
-  Array[String] $access_tags,
 ) {
   include mysql::server
 
@@ -654,20 +653,5 @@ class profile::freeipa::mokey (
     subscribe   => [
       Exec['ipa_self-signup_automember'],
     ],
-  }
-
-  $access_tags.each |$tag| {
-    exec { "ipa_hbacrule_self-signup_${tag}":
-      command     => "kinit_wrapper ipa hbacrule-add-user ${tag} --groups=self-signup",
-      refreshonly => true,
-      environment => ["IPA_ADMIN_PASSWD=${ipa_passwd}"],
-      require     => [File['kinit_wrapper'],],
-      path        => ['/bin', '/usr/bin', '/sbin','/usr/sbin'],
-      returns     => [0, 1, 2],
-      subscribe   => [
-        Exec['ipa_group_self-signup'],
-        Exec['hbac_rules'],
-      ],
-    }
   }
 }

--- a/site/profile/templates/freeipa/group_rules.py.epp
+++ b/site/profile/templates/freeipa/group_rules.py.epp
@@ -1,0 +1,13 @@
+#!/bin/bash
+api.Command.batch(
+<% if $hbacrules != undef { -%>
+  <% $hbacrules.each |$rule| { -%>
+  { 'method': 'hbacrule_add_user', 'params': [['<%= $rule %>'], {'group': '<%= $group %>'}] },
+  <% } -%>
+<% } -%>
+<% if $automember { -%>
+  { 'method': 'automember_add', 'params': [[], {'cn': '<%= $group %>', 'type': 'group', 'all': False, 'raw': False}]},
+  { 'method': 'automember_add_condition', 'params': [[], {'cn': '<%= $group %>', 'key': 'mail', 'type': 'group', 'all': False, 'raw': False, 'automemberinclusiveregex': '^(?!\s*$).+'}]},
+  { 'method': 'automember_rebuild', 'params': [[], {'type': 'group'}] },
+<% } -%>
+)


### PR DESCRIPTION
Groups can be defined and configured as: 
```
profile::users::ldap::groups:
  'def-sponsor00':
    automember: true
    hbacrules: ['login:sshd', 'node:sshd', 'proxy:jupyterhub-login']
``` 