### PR TITLE
Add support for specifying bsoft, bhard, isoft, ihard quotas

### DIFF
--- a/README.md
+++ b/README.md
@@ -1508,4 +1508,17 @@ profile::volumes::devices:
       #"filesystem": "xfs",
       #"quota": nil
 ```
+
+Default quotas on a filesystem can be defined as such:
+```yaml
+profile::volumes::devices:
+  "nfs":
+    "home":
+      "quota":
+        #"bsoft": "1g"
+        "bhard": "1g"
+        #"isoft": "500000"
+        "ihard": "500000"
+```
+
 </details>

--- a/data/common.yaml
+++ b/data/common.yaml
@@ -10,6 +10,8 @@ lookup_options:
     merge: 'deep'
   prometheus::extra_alert:
     merge: 'hash'
+  profile::volumes::devices:
+    merge: 'deep'
 
 profile::base::version: 14.3.0
 profile::base::packages: []


### PR DESCRIPTION
This PR enables defining inode quotas, and control soft and hard quotas explicitly. 