### PR TITLE
Test for the existence of log subfolder before wiping in prepare4image.sh

### DIFF
--- a/site/profile/files/base/prepare4image.sh
+++ b/site/profile/files/base/prepare4image.sh
@@ -30,10 +30,10 @@ systemctl daemon-reload
 
 systemctl stop rsyslog
 : > /var/log/messages
-: > /var/log/munge/munged.log
+test -d /var/log/munge && : > /var/log/munge/munged.log
 : > /var/log/secure
 : > /var/log/cron
-: > /var/log/audit/audit.log
+test -d /var/log/audit && : > /var/log/audit/audit.log
 
 if [ -f /etc/cloud/cloud-init.disabled ]; then
   # This is for GCP where we install cloud-init on first boot


### PR DESCRIPTION
In container image, audit is not installed which crashes the prepare4image.sh script.