### PR TITLE
Add option to configure puppetserver params that have impact on RAM

### DIFF
--- a/site/profile/manifests/puppetserver.pp
+++ b/site/profile/manifests/puppetserver.pp
@@ -1,4 +1,7 @@
-class profile::puppetserver {
+class profile::puppetserver (
+  Integer $jruby_max_active_instances = 1,
+  Integer $java_heap_size = 512,
+) {
   $eyaml_path = '/opt/puppetlabs/puppet/bin/eyaml'
   $boot_private_key_path = '/etc/puppetlabs/puppet/eyaml/boot_private_key.pkcs7.pem'
   $boot_eyaml = '/etc/puppetlabs/code/environments/production/data/bootstrap.yaml'
@@ -11,6 +14,22 @@ class profile::puppetserver {
         require => User[$user],
       }
     }
+  }
+
+  file_line { 'puppetserver_java_heap_size':
+    path   => '/etc/sysconfig/puppetserver',
+    match  => '^JAVA_ARGS=',
+    line   => "JAVA_ARGS=\"-Xms${java_heap_size}m -Xmx${java_heap_size}m -Djruby.logger.class=com.puppetlabs.jruby_utils.jruby.Slf4jLogger\"", #lint:ignore:140chars
+    notify => Service['puppetserver'],
+    tag    => ['mc_bootstrap'],
+  }
+
+  file_line { 'puppetserver_max_active_instances':
+    path   => '/etc/puppetlabs/puppetserver/conf.d/puppetserver.conf',
+    match  => '^    #max-active-instances:',
+    line   => "    max-active-instances: ${jruby_max_active_instances}",
+    notify => Service['puppetserver'],
+    tag    => ['mc_bootstrap'],
   }
 
   file { '/etc/puppetlabs/puppet/prometheus.yaml':


### PR DESCRIPTION
The default value of puppetserver for java heap and max active instances are typically too big for Magic Castle requirements.