### PR TITLE
Stop automatic upgrade of systemd

### DIFF
--- a/site/profile/manifests/freeipa.pp
+++ b/site/profile/manifests/freeipa.pp
@@ -19,7 +19,7 @@ class profile::freeipa::base (String $ipa_domain) {
   }
 
   package { 'systemd':
-    ensure => 'latest',
+    ensure => present,
   }
 
   package { 'NetworkManager':


### PR DESCRIPTION
In previous version of Magic Castle, we had issues with systemd that would be solved by upgrading it. Upgrading it automatically as soon as a new version is released can cause more harm than good, and have unexpected consequences for Magic Castle operators who do not expect packages to be upgraded automatically.