### PR TITLE
Refresh nvidia_gres.sh if generated content change

### DIFF
--- a/site/profile/manifests/slurm.pp
+++ b/site/profile/manifests/slurm.pp
@@ -706,10 +706,10 @@ class profile::slurm::node (
       ensure => present,
     }
     exec { 'slurm-nvidia_gres':
-      command     => '/opt/software/slurm/bin/nvidia_gres.sh > /etc/slurm/gres.conf',
-      refreshonly => true,
-      notify      => Service['slurmd'],
-      subscribe   => [
+      command   => '/opt/software/slurm/bin/nvidia_gres.sh > /etc/slurm/gres.conf',
+      unless    => '/opt/software/slurm/bin/nvidia_gres.sh | cmp -s - /etc/slurm/gres.conf',
+      notify    => Service['slurmd'],
+      subscribe => [
         File['/opt/software/slurm/bin/nvidia_gres.sh'],
         File['/etc/slurm/gres.conf'],
       ]


### PR DESCRIPTION
close #437 

This refresh `/etc/slurm/gres.conf` if the content generated by `/opt/software/slurm/bin/nvidia_gres.sh` differ.