### PR TITLE
Make puppet create /etc/ipa on the server before config files

### DIFF
--- a/site/profile/manifests/freeipa.pp
+++ b/site/profile/manifests/freeipa.pp
@@ -222,6 +222,13 @@ class profile::freeipa::server (
     include profile::freeipa::mokey
   }
 
+  file { '/etc/ipa':
+    ensure => directory,
+    owner  => 'root',
+    group  => 'root',
+    mode   => '0755',
+  }
+
   file { 'kinit_wrapper':
     path   => '/usr/bin/kinit_wrapper',
     source => 'puppet:///modules/profile/freeipa/kinit_wrapper',
@@ -237,7 +244,7 @@ class profile::freeipa::server (
 
   file { '/etc/ipa/dse-init.ldif':
     source  => 'puppet:///modules/profile/freeipa/dse-init.ldif',
-    require => Package['ipa-server-dns'],
+    require => File['/etc/ipa'],
   }
 
   if versioncmp($::facts['os']['release']['major'], '8') == 0 {
@@ -343,7 +350,7 @@ class profile::freeipa::server (
 
   file { '/etc/ipa/ipa_server_base_config.py':
     content => $ipa_server_base_config,
-    require => Exec['ipa-install'],
+    require => File['/etc/ipa'],
   }
 
   exec { 'ipa_server_base_config':
@@ -390,6 +397,7 @@ class profile::freeipa::server (
         'hbac_services' => $hbac_services,
       }
     ),
+    require => File['/etc/ipa'],
   }
 
   exec { 'hbac_rules':


### PR DESCRIPTION
In some circumstances, hbac_rules.py was created before ipa-install was executed and it would fail since /etc/ipa is missing. We solve this by creating /etc/ipa ourself.