### PR TITLE
Remove UsePSS in slurm.conf

### DIFF
--- a/site/profile/templates/slurm/slurm.conf.epp
+++ b/site/profile/templates/slurm/slurm.conf.epp
@@ -17,7 +17,7 @@ AccountingStorageTRES=gres/gpu,cpu,mem
 AccountingStorageEnforce=associations
 JobAcctGatherType=jobacct_gather/cgroup
 JobAcctGatherFrequency=task=30
-JobAcctGatherParams=NoOverMemoryKill,UsePSS
+JobAcctGatherParams=NoOverMemoryKill
 <% } -%>
 
 # MANAGEMENT POLICIES


### PR DESCRIPTION
Fix warning when launching slurmd
"slurmd: error: JobAcctGatherParams UsePSS and NoShared are only compatible with jobacct_gather/linux."