### PR TITLE
Fix jupyterhub destkop url

### DIFF
--- a/data/common.yaml
+++ b/data/common.yaml
@@ -76,7 +76,7 @@ jupyterhub::jupyterhub_config_hash:
         url: '/code-server'
       desktop:
         name: Desktop
-        url: '/Desktop'
+        url: '/desktop'
 
   SbatchForm:
     ui:


### PR DESCRIPTION
Since moving to official [jupyterhub desktop package](https://github.com/jupyterhub/jupyter-remote-desktop-proxy/blob/main/jupyter_remote_desktop_proxy/server_extension.py), the url is `/desktop`.