### PR TITLE
Fix unmounting nfs+bind to nfs when calling prepare4image.sh

### DIFF
--- a/site/profile/files/base/prepare4image.sh
+++ b/site/profile/files/base/prepare4image.sh
@@ -21,7 +21,7 @@ rm /opt/consul/node-id /opt/consul/checkpoint-signature /opt/consul/serf/local.s
 swapoff -a
 grep -q "swap" /etc/fstab && rm -f $(grep "swap" /etc/fstab | cut -f 1)
 # Unmount filesystems
-umount -a --types cephfs,nfs4
+umount -a --types cephfs,nfs4 -i
 # for xfs, we unmount only what's in /mnt, not things like / or /boot
 grep xfs /etc/fstab | cut -f 2 | grep /mnt | xargs --no-run-if-empty umount
 grep -P '(ext4|xfs|vfat|^#|^$)' /etc/fstab | grep -v /mnt > /etc/fstab.new


### PR DESCRIPTION
Fix this issue:
```
$ sudo /usr/sbin/prepare4image.sh
Removed "/etc/systemd/system/multi-user.target.wants/puppet.service".
Unenrolling client from IPA server
Removing Kerberos service principals from /etc/krb5.keytab
Disabling client Kerberos and LDAP configurations
Restoring client configuration files
Unconfiguring the NIS domain.
nscd daemon is not installed, skip configuration
nslcd daemon is not installed, skip configuration
Systemwide CA database updated.
Client uninstall complete.
The ipa-client-install command was successful
umount.nfs4: /nfs/scratch: is not an NFS filesystem
umount.nfs4: /nfs/project: is not an NFS filesystem
umount.nfs4: /nfs/home: is not an NFS filesystem
```