### PR TITLE
Second series of fix for disabling autofs

### DIFF
--- a/site/profile/manifests/cvmfs.pp
+++ b/site/profile/manifests/cvmfs.pp
@@ -76,15 +76,23 @@ class profile::cvmfs::client (
   }
 
   if Boolean($disable_autofs) {
+    service { 'autofs':
+      ensure => stopped,
+      enable => false,
+    }
     $repositories.each|$repository| {
       file { "${cvmfs_root}/${repository}":
         ensure  => directory,
-        require => File[$cvmfs_root],
+        require => [
+          File[$cvmfs_root],
+          Service['autofs'],
+        ],
       }
       -> mount { "${cvmfs_root}/${repository}":
         ensure  => 'mounted',
         device  => $repository,
         fstype  => 'cvmfs',
+        options => 'ro,_netdev',
         require => [
           Package['cvmfs'],
           File_line['cvmfs_default'],


### PR DESCRIPTION
* actually disable autofs when disable_autofs is set to true
* ensure that it is disabled before creating mount points
* mount cvmfs mounts as read only net devices