### PR TITLE
add openssh config with post-quantum kex algorithms for RHEL 9.8 and above

### DIFF
--- a/site/profile/files/base/opensshserver-9.8.config
+++ b/site/profile/files/base/opensshserver-9.8.config
@@ -1,0 +1,6 @@
+Ciphers chacha20-poly1305@openssh.com,aes256-gcm@openssh.com,aes128-gcm@openssh.com,aes256-ctr,aes192-ctr,aes128-ctr
+MACs hmac-sha2-256-etm@openssh.com,hmac-sha2-512-etm@openssh.com,umac-128-etm@openssh.com
+GSSAPIKexAlgorithms gss-curve25519-sha256-
+KexAlgorithms curve25519-sha256,curve25519-sha256@libssh.org,diffie-hellman-group16-sha512,diffie-hellman-group18-sha512,diffie-hellman-group-exchange-sha256,mlkem768x25519-sha256,sntrup761x25519-sha512
+HostKeyAlgorithms ssh-ed25519,ssh-ed25519-cert-v01@openssh.com,rsa-sha2-256,rsa-sha2-512
+PubkeyAcceptedKeyTypes ssh-ed25519,ssh-ed25519-cert-v01@openssh.com,rsa-sha2-256,rsa-sha2-512

--- a/site/profile/manifests/ssh.pp
+++ b/site/profile/manifests/ssh.pp
@@ -108,7 +108,7 @@ class profile::ssh::base (
       source => 'puppet:///modules/profile/base/opensshserver.config',
       notify => Service['sshd'],
     }
-  } elsif versioncmp($::facts['os']['release']['major'], '9') >= 0 {
+  } elsif versioncmp($::facts['os']['release']['major'], '9') == 0 and versioncmp($::facts['os']['release']['minor'], '8') < 0 {
     # In RedHat 9, the sshd policies are defined as an include of the
     # crypto policies. Parameters defined before the include supersede
     # the crypto policy. The include is done in a file named 50-redhat.conf.
@@ -117,6 +117,19 @@ class profile::ssh::base (
       owner   => 'root',
       group   => 'root',
       source  => 'puppet:///modules/profile/base/opensshserver-9.config',
+      notify  => Service['sshd'],
+      require => File['/etc/ssh/sshd_config.d'],
+    }
+  } elsif versioncmp($::facts['os']['release']['major'], '9') == 0 and versioncmp($::facts['os']['release']['minor'], '8') >= 0 {
+    # In RedHat 9, the sshd policies are defined as an include of the
+    # crypto policies. Parameters defined before the include supersede
+    # the crypto policy. The include is done in a file named 50-redhat.conf.
+    # RedHat 9.8 introduces support for Post-quantum Kex algorithms
+    file { '/etc/ssh/sshd_config.d/49-magic_castle.conf':
+      mode    => '0600',
+      owner   => 'root',
+      group   => 'root',
+      source  => 'puppet:///modules/profile/base/opensshserver-9.8.config',
       notify  => Service['sshd'],
       require => File['/etc/ssh/sshd_config.d'],
     }


### PR DESCRIPTION
This addresses https://github.com/ComputeCanada/puppet-magic_castle/issues/554 for RHEL 9.x.