### PR TITLE
Fix issue with slurm-job-exporter and Slurm 26

### DIFF
--- a/site/profile/templates/slurm/cgroup.conf.epp
+++ b/site/profile/templates/slurm/cgroup.conf.epp
@@ -8,3 +8,6 @@ AllowedSwapSpace=0
 MaxRAMPercent=100
 MaxSwapPercent=100
 MinRAMSpace=30
+<% if versioncmp($slurm_version, '26.05') >= 0 { -%>
+CgroupJobIdPaths=yes
+<% } -%>


### PR DESCRIPTION
The cgroups are named after SUID instead of JobID by default. This patch brings back the previous naming.