### PR TITLE
Define a principal specific for host enrollment instead of admin

### DIFF
--- a/README.md
+++ b/README.md
@@ -745,6 +745,22 @@ profile::freeipa::client::skip_ipa_install: false
 
 This class configures files and services of a FreeIPA server.
 
+After configuring the restricted host enrollment account, its permissions,
+and its password, the server publishes the DNS readiness marker
+`_mc-ipa-enrollment-ready.<ipa-domain> TXT "v1"`. Clients query the FreeIPA
+DNS server directly for this marker before enrolling. The marker represents
+completed enrollment provisioning and is monotonic: once published, it is not
+removed by Puppet.
+
+This readiness contract assumes that the enrollment principal, group, role,
+privilege, permissions, and supporting base configuration remain valid for the
+lifetime of the FreeIPA deployment. Changing the enrollment password alone is
+outside the marker's scope. The marker does not indicate current service
+health, and backups must not restore it without the corresponding enrollment
+configuration. Changes to the enrollment configuration on an existing
+deployment require rebuilding FreeIPA or explicitly removing the marker before
+reconciling the configuration.
+
 ### parameters
 
 | Variable         | Description                                 | Type           |
@@ -752,6 +768,7 @@ This class configures files and services of a FreeIPA server.
 | `id_start`       | Starting user and group id number           | Integer        |
 | `admin_password` | Password of the FreeIPA admin account       | String         |
 | `ds_password`    | Password of the directory server            | String         |
+| `host_enrollment_password` | Password of the restricted host enrollment account | String |
 | `hbac_services`  | Name of services to control with HBAC rules | Array[String]  |
 | `enable_mokey`   | Enable the [mokey service](#profilefreeipamokey) | Boolean   |
 
@@ -762,6 +779,7 @@ This class configures files and services of a FreeIPA server.
 profile::freeipa::server::id_start: 60001
 profile::freeipa::server::admin_password: ENC[PKCS7,...]
 profile::freeipa::server::ds_password: ENC[PKCS7,...]
+profile::freeipa::server::host_enrollment_password: ENC[PKCS7,...]
 profile::freeipa::server::hbac_services: ["sshd", "jupyterhub-login"]
 profile::freeipa::server::enable_mokey: true
 ```

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -12,6 +12,7 @@ ENC_CMD="eyaml encrypt -o block --pkcs7-public-key=${PKCS7_KEY}"
     $ENC_CMD -l 'profile::freeipa::mokey::password' -s $(openssl rand -base64 9)
     $ENC_CMD -l 'profile::freeipa::server::ds_password' -s $(openssl rand -base64 9)
     $ENC_CMD -l 'profile::freeipa::server::admin_password' -s $(openssl rand -base64 9)
+    $ENC_CMD -l 'profile::freeipa::server::host_enrollment_password' -s $(openssl rand -base64 9)
     $ENC_CMD -l 'metrix::password' -s $(openssl rand -base64 9)
     $ENC_CMD -l 'metrix::slurm_password' -s $(openssl rand -base64 9)
     $ENC_CMD -l 'metrix::root_api_token' -s $(openssl rand -hex 20)

--- a/data/environment/image.yaml
+++ b/data/environment/image.yaml
@@ -6,3 +6,4 @@ consul::service_ensure: 'stopped'
 profile::gpu::install::load_modules: false
 profile::consul::acl_api_token: 'IMAGE-ENV-PLACEHOLDER'
 profile::freeipa::server::admin_password: 'IMAGE-ENV-PLACEHOLDER'
+profile::freeipa::server::host_enrollment_password: 'IMAGE-ENV-PLACEHOLDER'

--- a/site/profile/files/freeipa/ipa_host_enrollment_config.py
+++ b/site/profile/files/freeipa/ipa_host_enrollment_config.py
@@ -1,0 +1,115 @@
+api.Command.batch(
+    {
+        'method': 'group_add',
+        'params': [[
+            'host-enrollers',
+        ], {
+            'description': 'Accounts allowed to enroll hosts',
+            'nonposix': True,
+        }],
+    },
+    {
+        'method': 'pwpolicy_add',
+        'params': [[
+            'host-enrollers',
+        ], {
+            'krbminpwdlife': 0,
+            'krbmaxpwdlife': 0,
+            'cospriority': 2,
+        }],
+    },
+    {
+        'method': 'user_add',
+        'params': [[
+            'host_enrollment',
+        ], {
+            'givenname': 'Host',
+            'sn': 'Enrollment',
+            'loginshell': '/sbin/nologin',
+        }],
+    },
+    {
+        'method': 'group_add_member',
+        'params': [['host-enrollers'], {'user': 'host_enrollment'}],
+    },
+    {
+        'method': 'privilege_add',
+        'params': [[
+            'Magic Castle Host Enrollment',
+        ], {
+            'description': 'Permissions required to enroll Magic Castle hosts',
+        }],
+    },
+    {
+        'method': 'privilege_add_permission',
+        'params': [[
+            'Magic Castle Host Enrollment',
+        ], {
+            'permission': 'System: Add Hosts',
+        }],
+    },
+    {
+        'method': 'privilege_add_permission',
+        'params': [[
+            'Magic Castle Host Enrollment',
+        ], {
+            'permission': 'System: Add krbPrincipalName to a Host',
+        }],
+    },
+    {
+        'method': 'privilege_add_permission',
+        'params': [[
+            'Magic Castle Host Enrollment',
+        ], {
+            'permission': 'System: Enroll a Host',
+        }],
+    },
+    {
+        'method': 'privilege_add_permission',
+        'params': [[
+            'Magic Castle Host Enrollment',
+        ], {
+            'permission': 'System: Manage Host Keytab',
+        }],
+    },
+    {
+        'method': 'privilege_add_permission',
+        'params': [[
+            'Magic Castle Host Enrollment',
+        ], {
+            'permission': 'System: Manage Host Certificates',
+        }],
+    },
+    {
+        'method': 'privilege_add_permission',
+        'params': [[
+            'Magic Castle Host Enrollment',
+        ], {
+            'permission': 'System: Manage Host Principals',
+        }],
+    },
+    {
+        'method': 'role_add',
+        'params': [[
+            'Magic Castle Host Enrollment',
+        ], {
+            'description': 'Enroll Magic Castle hosts',
+        }],
+    },
+    {
+        'method': 'role_add_privilege',
+        'params': [[
+            'Magic Castle Host Enrollment',
+        ], {
+            'privilege': 'Magic Castle Host Enrollment',
+        }],
+    },
+    {
+        'method': 'role_add_member',
+        'params': [[
+            'Magic Castle Host Enrollment',
+        ], {
+            'user': 'host_enrollment',
+        }],
+    },
+)

--- a/site/profile/manifests/freeipa.pp
+++ b/site/profile/manifests/freeipa.pp
@@ -527,7 +527,7 @@ class profile::freeipa::server (
   # the puppet server during the bootstrap phase and it can
   # change if the puppet server is reinstalled.
   $ds_file = "/etc/dirsrv/slapd-${ds_domain}/dse.ldif"
-  $reset_ds_password_cmd = @("EOT")
+  $reconcile_ds_password_cmd = @("EOT")
     dsctl ${ds_domain} stop && \
     sed -n ':loop N; s/\n //; t loop; P; D' ${ds_file} |\
         sed "s;^nsslapd-rootpw:.*$;nsslapd-rootpw: $(pwdhash ${ds_password});g" \
@@ -536,8 +536,8 @@ class profile::freeipa::server (
     dsctl ${ds_domain} start
     |EOT
   $check_ds_password_cmd = "pwdhash -c $(sed -n ':loop N; s/\\n //; t loop; P; D' ${ds_file} | grep -oP 'nsslapd-rootpw: \\K(.*)') ${ds_password}" # lint:ignore:140chars
-  exec { 'reset ds password':
-    command => Sensitive($reset_ds_password_cmd),
+  exec { 'reconcile ds password':
+    command => Sensitive($reconcile_ds_password_cmd),
     unless  => Sensitive($check_ds_password_cmd),
     path    => ['/usr/sbin', '/usr/bin', '/bin'],
     require => Service["dirsrv@${ds_domain}"],
@@ -562,7 +562,7 @@ class profile::freeipa::server (
     path        => ['/usr/sbin', '/usr/bin', '/bin'],
     require     => [
       Service["dirsrv@${ds_domain}"],
-      Exec['reset ds password'],
+      Exec['reconcile ds password'],
     ],
   }
 

--- a/site/profile/manifests/freeipa.pp
+++ b/site/profile/manifests/freeipa.pp
@@ -20,6 +20,8 @@ class profile::freeipa::base (Stdlib::Fqdn $ipa_domain) {
 
   package { 'sssd-dbus': }
 
+  package { 'bind-utils': }
+
   service { 'NetworkManager':
     ensure  => running,
     enable  => true,
@@ -45,10 +47,7 @@ class profile::freeipa::client (
   include profile::sssd::client
 
   $ipa_domain = lookup('profile::freeipa::base::ipa_domain')
-  $admin_password = lookup('profile::freeipa::server::admin_password')
   $fqdn = "${facts['networking']['hostname']}.${ipa_domain}"
-  $realm = upcase($ipa_domain)
-  $ipaddress = lookup('terraform.self.local_ip')
 
   if $facts['virtual'] =~ /^(container|lxc).*$/ {
     file_line { 'chronyd_disable_clock_control':
@@ -116,45 +115,35 @@ class profile::freeipa::client (
 
 class profile::freeipa::client::install {
   $ipa_domain = lookup('profile::freeipa::base::ipa_domain')
-  $admin_password = lookup('profile::freeipa::server::admin_password')
+  $server_ip = lookup('profile::freeipa::client::server_ip')
+  $host_enrollment_password = lookup('profile::freeipa::server::host_enrollment_password')
   $fqdn = "${facts['networking']['hostname']}.${ipa_domain}"
-  $realm = upcase($ipa_domain)
   $ipaddress = lookup('terraform.self.local_ip')
 
-  # We want to wait for the FreeIPA server to be fully configured
-  # before launching the FreeIPA client install. The mechanism we
-  # found thus far to validate the server is operational is to
-  # try to fetch the SSL certificate of the host ipa on port 443.
-  # We wait at most 20 minutes - polling every 10 seconds (polling_frequency)
-  # at most 120 times (max_retries). We chose 20 minutes as it
-  # the most time require to fully configure a node with the mgmt
-  # tag as of Magic Castle 15.
-  exec { 'is_ipa-client_installed':
-    command  => ':',
-    provider => shell,
-    unless   => ['/usr/bin/test -f /etc/ipa/default.conf'],
-    notify   => Wait_for['ipa_https'],
-  }
-  wait_for { 'ipa_https':
-    query             => "openssl s_client -showcerts -connect ipa:443 </dev/null 2> /dev/null | openssl x509 -noout -text | grep --quiet DNS:ipa.${ipa_domain}",
-    exit_code         => 0,
-    polling_frequency => 10,
-    max_retries       => 120,
-    refreshonly       => true,
-    subscribe         => [
+  # Query the IPA DNS server directly for the marker published after the
+  # server-side enrollment configuration completes. Wait at most 20 minutes,
+  # polling every 10 seconds.
+  $ipa_host_enrollment_ready_cmd = "/usr/bin/dig +short TXT @${server_ip} _mc-ipa-enrollment-ready.${ipa_domain} | /usr/bin/grep --fixed-strings --line-regexp --quiet '\"v1\"'" # lint:ignore:140chars
+  exec { 'ipa_host_enrollment_ready':
+    command   => $ipa_host_enrollment_ready_cmd,
+    unless    => '/usr/bin/test -f /etc/ipa/default.conf',
+    tries     => 120,
+    try_sleep => 10,
+    require   => [
+      Package['bind-utils'],
       Package['ipa-client'],
       Exec['ipa-client-uninstall_bad-hostname'],
       Exec['ipa-client-uninstall_bad-server'],
     ],
   }
 
-  # Make sure heavy lifting operations are done before waiting on mgmt1
-  Archive <| |> -> Wait_for['ipa_https']
-  Package <| |> -> Wait_for['ipa_https']
-  Selinux::Module <| |> -> Wait_for['ipa_https']
-  Selinux::Boolean <| |> -> Wait_for['ipa_https']
-  Selinux::Exec_restorecon <| |> -> Wait_for['ipa_https']
-  Uv::Venv <| |> -> Wait_for['ipa_https']
+  # Make sure heavy lifting operations are done before waiting on mgmt1.
+  Archive <| |> -> Exec['ipa_host_enrollment_ready']
+  Package <| |> -> Exec['ipa_host_enrollment_ready']
+  Selinux::Module <| |> -> Exec['ipa_host_enrollment_ready']
+  Selinux::Boolean <| |> -> Exec['ipa_host_enrollment_ready']
+  Selinux::Exec_restorecon <| |> -> Exec['ipa_host_enrollment_ready']
+  Uv::Venv <| |> -> Exec['ipa_host_enrollment_ready']
 
   $ipa_client_install_cmd = @("IPACLIENTINSTALL"/L)
     /sbin/mc-ipa-client-install \
@@ -164,8 +153,8 @@ class profile::freeipa::client::install {
     --ssh-trust-dns \
     --unattended \
     --force-join \
-    -p admin \
-    -w ${admin_password}
+    -p host_enrollment \
+    -w ${host_enrollment_password}
     | IPACLIENTINSTALL
 
   exec { 'ipa-install':
@@ -177,7 +166,7 @@ class profile::freeipa::client::install {
       File['/sbin/mc-ipa-client-install'],
       File['/etc/NetworkManager/conf.d/zzz-puppet.conf'],
       Exec['set_hostname'],
-      Wait_for['ipa_https'],
+      Exec['ipa_host_enrollment_ready'],
       Augeas['sssd.conf'],
     ],
     creates   => '/etc/ipa/default.conf',
@@ -240,6 +229,7 @@ class profile::freeipa::server (
   Integer $id_start,
   String $admin_password,
   String $ds_password,
+  String $host_enrollment_password,
   Array[String] $hbac_services = ['sshd', 'jupyterhub-login'],
   Boolean $enable_mokey = true,
 ) {
@@ -366,10 +356,56 @@ class profile::freeipa::server (
     path        => ['/bin', '/usr/bin', '/sbin','/usr/sbin'],
   }
 
+  file { '/etc/ipa/ipa_host_enrollment_config.py':
+    mode    => '0700',
+    source  => 'puppet:///modules/profile/freeipa/ipa_host_enrollment_config.py',
+    require => File['/etc/ipa'],
+  }
+
+  exec { 'ipa_host_enrollment_config':
+    command     => 'kinit_wrapper ipa console /etc/ipa/ipa_host_enrollment_config.py',
+    refreshonly => true,
+    subscribe   => File['/etc/ipa/ipa_host_enrollment_config.py'],
+    environment => ["IPA_ADMIN_PASSWD=${admin_password}"],
+    path        => ['/bin', '/usr/bin', '/sbin','/usr/sbin'],
+    require     => [
+      File['/etc/ipa/ipa_host_enrollment_config.py'],
+      Exec['ipa_server_base_config'],
+    ],
+  }
+
+  $ldap_dc_string = join(split($ipa_domain, '[.]').map |$dc| { "dc=${dc}" }, ',')
+  $reset_host_enrollment_password_cmd = @("EOT")
+    ldappasswd -ZZ -D 'cn=Directory Manager' -w ${ds_password} \
+      -S uid=host_enrollment,cn=users,cn=accounts,${ldap_dc_string} \
+      -s ${host_enrollment_password} -H ldap://${fqdn} && \
+    echo ${host_enrollment_password} | kinit host_enrollment && kdestroy
+    |EOT
+  $check_host_enrollment_password_cmd = "echo ${host_enrollment_password} | kinit host_enrollment && kdestroy"
+  exec { 'reset host enrollment password':
+    command     => Sensitive($reset_host_enrollment_password_cmd),
+    unless      => Sensitive($check_host_enrollment_password_cmd),
+    environment => ['KRB5CCNAME=FILE:/run/ipa-host-enrollment-password-check.ccache'],
+    path        => ['/usr/sbin', '/usr/bin', '/bin'],
+    require     => Exec['ipa_host_enrollment_config'],
+  }
+
+  exec { 'publish ipa host enrollment readiness':
+    command     => "kinit_wrapper ipa dnsrecord-add ${ipa_domain} _mc-ipa-enrollment-ready --txt-rec=v1",
+    unless      => "/usr/bin/dig +short TXT @127.0.0.1 _mc-ipa-enrollment-ready.${ipa_domain} | /usr/bin/grep --fixed-strings --line-regexp --quiet '\"v1\"'", # lint:ignore:140chars
+    environment => ["IPA_ADMIN_PASSWD=${admin_password}"],
+    path        => ['/bin', '/usr/bin', '/sbin','/usr/sbin'],
+    require     => [
+      Exec['reset host enrollment password'],
+      Package['bind-utils'],
+    ],
+  }
+
   # Configure the password of the admin accounts to never expire
-  ~> exec { 'ipa_admin_passwd_reset':
+  exec { 'ipa_admin_passwd_reset':
     command     => 'echo -e "$IPA_ADMIN_PASSWD\n$IPA_ADMIN_PASSWD\n$IPA_ADMIN_PASSWD" | kinit_wrapper kpasswd',
     refreshonly => true,
+    subscribe   => Exec['ipa_server_base_config'],
     environment => ["IPA_ADMIN_PASSWD=${admin_password}"],
     path        => ['/bin', '/usr/bin', '/sbin','/usr/sbin'],
   }
@@ -497,7 +533,6 @@ class profile::freeipa::server (
     require => Service["dirsrv@${ds_domain}"],
   }
 
-  $ldap_dc_string = join(split($ipa_domain, '[.]').map |$dc| { "dc=${dc}" }, ',')
   $reset_admin_password_cmd = @("EOT")
     ldappasswd -ZZ -D 'cn=Directory Manager' -w ${ds_password} \
       -S uid=admin,cn=users,cn=accounts,${ldap_dc_string} \

--- a/site/profile/manifests/freeipa.pp
+++ b/site/profile/manifests/freeipa.pp
@@ -262,6 +262,7 @@ class profile::freeipa::server (
 
   $realm = upcase($ipa_domain)
   $fqdn = "${facts['networking']['hostname']}.${ipa_domain}"
+  $ldap_dc_string = join(split($ipa_domain, '[.]').map |$dc| { "dc=${dc}" }, ',')
   $reverse_zone = profile::getreversezone()
   $ipaddress = lookup('terraform.self.local_ip')
   $ds_domain = regsubst($realm, '\.', '-', 'G')
@@ -301,6 +302,7 @@ class profile::freeipa::server (
       File['/etc/ssh/sshd_config.d'],
     ],
     notify  => [
+      Exec['clear admin password expiration date'],
       Service['systemd-logind'],
       Service['sssd'],
       Service['httpd'],
@@ -350,10 +352,28 @@ class profile::freeipa::server (
     require     => [
       File['/etc/ipa/ipa_server_base_config.py'],
       Exec['ipa-install'],
+      Exec['reconcile admin password'],
     ],
     subscribe   => File['/etc/ipa/ipa_server_base_config.py'],
     environment => ["IPA_ADMIN_PASSWD=${admin_password}"],
     path        => ['/bin', '/usr/bin', '/sbin','/usr/sbin'],
+  }
+
+  # Make sure admin password never expires by removing
+  # its expiration attribute from LDAP. This is only
+  # notified by ipa-server-install.
+  $clear_admin_password_expiration_cmd = @("EOT"/L$)
+    printf '%s\n' \
+      'dn: uid=admin,cn=users,cn=accounts,${ldap_dc_string}' \
+      'changetype: modify' \
+      'delete: krbPasswordExpiration' |
+    ldapmodify -ZZ -H ldap://${fqdn} -D 'cn=Directory Manager' -w "\$IPA_DS_PASSWD"
+    | EOT
+  exec { 'clear admin password expiration date':
+    command     => $clear_admin_password_expiration_cmd,
+    refreshonly => true,
+    environment => ["IPA_DS_PASSWD=${ds_password}"],
+    path        => ['/usr/bin', '/bin'],
   }
 
   file { '/etc/ipa/ipa_host_enrollment_config.py':
@@ -374,7 +394,6 @@ class profile::freeipa::server (
     ],
   }
 
-  $ldap_dc_string = join(split($ipa_domain, '[.]').map |$dc| { "dc=${dc}" }, ',')
   $reset_host_enrollment_password_cmd = @("EOT")
     ldappasswd -ZZ -D 'cn=Directory Manager' -w ${ds_password} \
       -S uid=host_enrollment,cn=users,cn=accounts,${ldap_dc_string} \
@@ -399,15 +418,6 @@ class profile::freeipa::server (
       Exec['reset host enrollment password'],
       Package['bind-utils'],
     ],
-  }
-
-  # Configure the password of the admin accounts to never expire
-  exec { 'ipa_admin_passwd_reset':
-    command     => 'echo -e "$IPA_ADMIN_PASSWD\n$IPA_ADMIN_PASSWD\n$IPA_ADMIN_PASSWD" | kinit_wrapper kpasswd',
-    refreshonly => true,
-    subscribe   => Exec['ipa_server_base_config'],
-    environment => ["IPA_ADMIN_PASSWD=${admin_password}"],
-    path        => ['/bin', '/usr/bin', '/sbin','/usr/sbin'],
   }
 
   $regen_cert_cmd = 'ipa-getcert list | grep -oP "Request ID \'\K[^\']+" | xargs -I \'{}\' ipa-getcert resubmit -i \'{}\' -w'
@@ -533,17 +543,24 @@ class profile::freeipa::server (
     require => Service["dirsrv@${ds_domain}"],
   }
 
-  $reset_admin_password_cmd = @("EOT")
-    ldappasswd -ZZ -D 'cn=Directory Manager' -w ${ds_password} \
+  # Compare the actual FreeIPA admin credential with the password declared in Puppet,
+  # and update FreeIPA only when they differ.
+  $configure_admin_password_cmd = @("EOT"/$)
+    ldappasswd -ZZ -D 'cn=Directory Manager' -w "\$IPA_DS_PASSWD" \
       -S uid=admin,cn=users,cn=accounts,${ldap_dc_string} \
-      -s ${admin_password} -H ldap://${fqdn}
+      -s "\$IPA_ADMIN_PASSWD" -H ldap://${fqdn}
     |EOT
-  $check_admin_password_cmd = "echo ${admin_password} | kinit admin && kdestroy"
-  exec { 'reset admin password':
-    command => Sensitive($reset_admin_password_cmd),
-    unless  => Sensitive($check_admin_password_cmd),
-    path    => ['/usr/sbin', '/usr/bin', '/bin'],
-    require => [
+  $check_admin_password_cmd = 'echo "$IPA_ADMIN_PASSWD" | kinit admin && kdestroy'
+  exec { 'reconcile admin password':
+    command     => $configure_admin_password_cmd,
+    unless      => $check_admin_password_cmd,
+    environment => [
+      "IPA_ADMIN_PASSWD=${admin_password}",
+      "IPA_DS_PASSWD=${ds_password}",
+      'KRB5CCNAME=FILE:/run/ipa-admin-password-check.ccache',
+    ],
+    path        => ['/usr/sbin', '/usr/bin', '/bin'],
+    require     => [
       Service["dirsrv@${ds_domain}"],
       Exec['reset ds password'],
     ],


### PR DESCRIPTION
This PR replaces the FreeIPA admin credential used for host enrollment with a dedicated least-privileged host_enrollment account.

  - Creates a non-login enrollment user with a generated encrypted password.
  - Creates a dedicated role and privilege containing only permissions needed to add, enroll, and force-reenroll hosts.
  - Uses the restricted principal with ipa-client-install --force-join.
  - Publishes `_mc-ipa-enrollment-ready.<domain> TXT "v1"` after enrollment provisioning completes.
  - Makes clients query the authoritative IPA DNS server for this marker instead of waiting for the `ipa.<domain>` HTTPS certificate.
  - Stores the enrollment configuration in a standalone Python file.
  - Documents that the readiness marker is a monotonic provisioning marker, not a live health check.

  The marker assumes enrollment configuration remains valid for the lifetime of the FreeIPA deployment. Password-only changes and out-of-band changes are outside its scope.
